### PR TITLE
Add Trip Cams side project to portfolio bio

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
         </header>
         <p>I'm a product designer who likes to make complicated things simple. Right now, that means designing for AI Wearables at <a href="https://meta.com" target="_blank" rel="noopener noreferrer">Meta</a>'s Reality Labs, where I've been part of launching category-defining products.</p>
         <p>I believe great design comes from combining deep understanding and craft to build beautiful things that people love. My background spans product strategy, interaction design, design leadership, and front-end development — I've always built as much as I've designed.</p>
+        <p>Lately, I've been tinkering on a side project called <a href="https://tripcams.zacharyhalvorson.com" target="_blank" rel="noopener noreferrer">Trip Cams</a> — a web app that shows live highway camera feeds along your driving route, so you can check road conditions before you hit the road.</p>
         <p>If you'd like to connect, feel free to <a href="mailto:hello@zacharyhalvorson.com">email me</a>.</p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
         </header>
         <p>I'm a product designer who likes to make complicated things simple. Right now, that means designing for AI Wearables at <a href="https://meta.com" target="_blank" rel="noopener noreferrer">Meta</a>'s Reality Labs, where I've been part of launching category-defining products.</p>
         <p>I believe great design comes from combining deep understanding and craft to build beautiful things that people love. My background spans product strategy, interaction design, design leadership, and front-end development — I've always built as much as I've designed.</p>
-        <p>Lately, I've been tinkering on a side project called <a href="https://tripcams.zacharyhalvorson.com" target="_blank" rel="noopener noreferrer">Trip Cams</a> — a web app that shows live highway camera feeds along your driving route, so you can check road conditions before you hit the road.</p>
+        <p>Lately, I've been tinkering on a side project called <a href="https://tripcams.zacharyhalvorson.com" target="_blank" rel="noopener noreferrer">Trip Cams</a>, a web app that shows live highway camera feeds along your driving route so you can check road conditions before you hit the road.</p>
         <p>If you'd like to connect, feel free to <a href="mailto:hello@zacharyhalvorson.com">email me</a>.</p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
         </header>
         <p>I'm a product designer who likes to make complicated things simple. Right now, that means designing for AI Wearables at <a href="https://meta.com" target="_blank" rel="noopener noreferrer">Meta</a>'s Reality Labs, where I've been part of launching category-defining products.</p>
         <p>I believe great design comes from combining deep understanding and craft to build beautiful things that people love. My background spans product strategy, interaction design, design leadership, and front-end development — I've always built as much as I've designed.</p>
-        <p>Lately, I've been tinkering on a side project called <a href="https://tripcams.zacharyhalvorson.com" target="_blank" rel="noopener noreferrer">Trip Cams</a>, a web app that shows live highway camera feeds along your driving route so you can check road conditions before you hit the road.</p>
+        <p>Lately, I've been tinkering on a side project called <a href="https://tripcams.zacharyhalvorson.com" target="_blank" rel="noopener noreferrer" title="Try it out!">Trip Cams</a>, a web app that shows live highway camera feeds along your driving route so you can check road conditions before you hit the road.</p>
         <p>If you'd like to connect, feel free to <a href="mailto:hello@zacharyhalvorson.com">email me</a>.</p>
       </section>
 


### PR DESCRIPTION
## Summary
Updated the portfolio bio section to include information about a new side project called Trip Cams.

## Changes
- Added a new paragraph describing Trip Cams, a web app that displays live highway camera feeds along driving routes
- Included a link to the Trip Cams website (https://tripcams.zacharyhalvorson.com) with proper accessibility attributes (target="_blank" and rel="noopener noreferrer")
- Positioned the new content between the existing design philosophy paragraph and contact information

## Details
This addition provides visitors with insight into recent personal projects and demonstrates continued engagement with web development and product creation beyond professional work at Meta.

https://claude.ai/code/session_015XZtPr3raBtGS6K33wYwmR