### PR TITLE
Update Trip Cams link to tripcams.pizza

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
         </header>
         <p>I'm a product designer who likes to make complicated things simple. Right now, that means designing for AI Wearables at <a href="https://meta.com" target="_blank" rel="noopener noreferrer">Meta</a>'s Reality Labs, where I've been part of launching category-defining products.</p>
         <p>I believe great design comes from combining deep understanding and craft to build beautiful things that people love. My background spans product strategy, interaction design, design leadership, and front-end development — I've always built as much as I've designed.</p>
-        <p>Lately, I've been tinkering on a side project called <a href="https://tripcams.zacharyhalvorson.com" target="_blank" rel="noopener noreferrer" title="Try it out!">Trip Cams</a>, a web app that shows live highway camera feeds along your driving route so you can check road conditions before you hit the road.</p>
+        <p>Lately, I've been tinkering on a side project called <a href="https://tripcams.pizza" target="_blank" rel="noopener noreferrer" title="Try it out!">Trip Cams</a>, a web app that shows live highway camera feeds along your driving route so you can check road conditions before you hit the road.</p>
         <p>If you'd like to connect, feel free to <a href="mailto:hello@zacharyhalvorson.com">email me</a>.</p>
       </section>
 


### PR DESCRIPTION
## Summary
- Update the Trip Cams link in the bio from `tripcams.zacharyhalvorson.com` to `tripcams.pizza`

## Test plan
- [ ] Verify link in bio paragraph points to https://tripcams.pizza
- [ ] Link still opens in a new tab with `rel="noopener noreferrer"`

https://claude.ai/code/session_01NdsMQBV1b3cDMs8trzttcj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdsMQBV1b3cDMs8trzttcj)_