### PR TITLE
Mobile fixes: vertical scroll, horizontal overflow, stack shadows

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,11 +16,11 @@
 
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.zacharyhalvorson.com/">
-    <meta property="og:title" content="Zachary Halvorson, Product Designer">
+    <meta property="og:title" content="Zachary Halvorson">
     <meta property="og:description" content="Selected work by a product designer in Seattle. AI smart glasses at Meta Reality Labs, the Clio Scheduler, and Dooly.">
     <meta property="og:image" content="https://www.zacharyhalvorson.com/embed-image.png">
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="Zachary Halvorson, Product Designer">
+    <meta name="twitter:title" content="Zachary Halvorson">
     <meta name="twitter:description" content="Selected work by a product designer in Seattle. AI smart glasses at Meta Reality Labs, the Clio Scheduler, and Dooly.">
     <meta name="twitter:image" content="https://www.zacharyhalvorson.com/embed-image.png">
 

--- a/style.css
+++ b/style.css
@@ -57,6 +57,10 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+  /* Contain decorative overflow (stacked media transforms, card shadows) so
+     mobile browsers don't expose a horizontal pan. `clip` doesn't create a
+     scroll container, so the y-axis snap on <html> is unaffected. */
+  overflow-x: clip;
 }
 
 img, picture { display: block; max-width: 100%; height: auto; }
@@ -449,7 +453,7 @@ ul, ol, dl, dd { margin: 0; padding: 0; }
 }
 .media_item {
   /* drop-shadow follows the squircle clip-path on the inner img/video */
-  filter: drop-shadow(0 18px 30px rgba(0, 0, 0, 0.18));
+  filter: drop-shadow(0 14px 26px rgba(0, 0, 0, 0.14));
 }
 .media_item img,
 .media_item video {
@@ -520,7 +524,10 @@ ul, ol, dl, dd { margin: 0; padding: 0; }
   height: clamp(280px, 52svh, 520px);
   cursor: grab;
   outline: none;
-  touch-action: none;
+  /* pan-y lets the browser own vertical scroll on the stack itself, so a swipe
+     up to reach the next section just works; JS still claims horizontal moves
+     for leafing through the cards. */
+  touch-action: pan-y;
   user-select: none;
 }
 /* On narrow viewports the figure was reserving far more vertical space than
@@ -563,6 +570,13 @@ ul, ol, dl, dd { margin: 0; padding: 0; }
 .media.is-stack .media_item.is-hidden {
   opacity: 0;
   pointer-events: none;
+}
+/* Rear cards wear a much softer shadow than the front card. Without this, the
+   front card's heavy drop-shadow lands on the white surface of the card behind
+   it and reads as a clipped, banded mess (especially obvious on light hero
+   images like Dooly). */
+.media.is-stack .media_item:not(.is-front) {
+  filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.08));
 }
 .media.is-stack .media_item.is-source {
   visibility: hidden;


### PR DESCRIPTION
## Summary

Three mobile-browser fixes:

- **Vertical scroll on media stacks.** Swiping up on a card now scrolls the page to the next section instead of getting trapped by the stack's pointer handlers. `.media.is-stack` switches from `touch-action: none` to `touch-action: pan-y`, so the browser owns vertical pans while JS keeps horizontal swipes for leafing through cards. The existing `pointercancel` path already cleans up state when the browser claims the gesture.
- **Horizontal page pan.** At 375px the document overflowed by 24px (stack transforms pushing rear cards past the right edge), allowing the page to pan right on phones. `body { overflow-x: clip }` contains decorative overflow without creating a scroll container, so the y-axis snap on `<html>` is unaffected.
- **Stack shadows.** The front card's drop-shadow was identical to the rear cards' and landed on their light surface as a compounded, banded, clipped-looking edge — most obvious on the Dooly hero. Slightly softened the base shadow (`0 18px 30px / 0.18` → `0 14px 26px / 0.14`) and gave non-front stack cards a much lighter `0 4px 10px / 0.08`, so rear cards whisper "I'm behind" instead of stacking up dark edges.

Also bundled in a separate commit: shortening `og:title` and `twitter:title` from "Zachary Halvorson, Product Designer" to "Zachary Halvorson".

## Test plan

- [ ] On iOS Safari / Chrome at phone width, swipe vertically on a media stack — page scrolls to the next chapter.
- [ ] On iOS Safari / Chrome at phone width, swipe horizontally on a media stack — cards leaf, page doesn't scroll.
- [ ] At 375px width, confirm `document.documentElement.scrollWidth === window.innerWidth` (no horizontal pan).
- [ ] Dooly section: rear cards behind the active card have subtle, not banded, shadows.
- [ ] Tap a card to open the lightbox — open/close FLIP morph still works.
- [ ] Desktop view at >=980px is unchanged.
- [ ] OG/Twitter card previews show the shorter title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)