### PR TITLE
Optimize resume for AI/ATS screening

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,11 @@
     <script src="./script.js?v=20260527i" defer></script>
     <link rel="canonical" href="https://zacharyhalvorson.com/">
 
-    <title>Zachary Halvorson — Staff Product Designer</title>
-    <meta name="description" content="Zachary Halvorson is a Staff Product Designer focused on AI Design and Building. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
+    <title>Zachary Halvorson — Staff Product Designer · AI &amp; Generative UX</title>
+    <meta name="description" content="Zachary Halvorson is a Staff Product Designer with 10+ years specializing in AI-native and generative UX, interaction design, and design systems. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly. Open to Staff-level roles in Seattle, remote, California, or Canada.">
     <meta name="author" content="Zachary Halvorson">
+    <meta name="keywords" content="Staff Product Designer, AI-native UX, Generative UI, Interaction Design, Design Systems, Prototyping, AR, Wearables, Design Leadership, Product Design, UX Design, Seattle, Remote">
+    <meta name="robots" content="index, follow">
 
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#262626" media="(prefers-color-scheme: dark)">
@@ -19,7 +21,7 @@
     <meta property="og:locale" content="en_US">
     <meta property="og:url" content="https://zacharyhalvorson.com/">
     <meta property="og:title" content="Zachary Halvorson — Staff Product Designer">
-    <meta property="og:description" content="Staff Product Designer focused on AI Design and Building. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
+    <meta property="og:description" content="Staff Product Designer specializing in AI-native and generative UX. 10+ years shipping products — Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
     <meta property="og:image" content="https://zacharyhalvorson.com/embed-image.jpg">
     <meta property="og:image:type" content="image/jpeg">
     <meta property="og:image:width" content="1200">
@@ -28,7 +30,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:creator" content="@zachhalvorson">
     <meta name="twitter:title" content="Zachary Halvorson — Staff Product Designer">
-    <meta name="twitter:description" content="Staff Product Designer focused on AI Design and Building. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
+    <meta name="twitter:description" content="Staff Product Designer specializing in AI-native and generative UX. 10+ years shipping products — Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
     <meta name="twitter:image" content="https://zacharyhalvorson.com/embed-image.jpg">
     <meta name="twitter:image:alt" content="Portrait of Zachary Halvorson.">
 
@@ -53,7 +55,35 @@
       "name": "Zachary Halvorson",
       "url": "https://zacharyhalvorson.com/",
       "image": "https://zacharyhalvorson.com/embed-image.jpg",
+      "email": "zacharyhalvorson@me.com",
       "jobTitle": "Staff Product Designer",
+      "description": "Staff Product Designer with 10+ years specializing in AI-native and generative UX, interaction design, design systems, and prototyping. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.",
+      "homeLocation": { "@type": "Place", "name": "Seattle, WA, USA" },
+      "knowsAbout": [
+        "Product Design",
+        "AI-native UX",
+        "Generative UI",
+        "Interaction Design",
+        "Design Systems",
+        "Prototyping",
+        "Front-End Development",
+        "AR and Wearables",
+        "Design Leadership",
+        "User Experience Design",
+        "0-to-1 Product Design",
+        "Mentorship"
+      ],
+      "hasOccupation": {
+        "@type": "Occupation",
+        "name": "Staff Product Designer",
+        "occupationalCategory": "15-1255.00 Web and Digital Interface Designers",
+        "skills": "AI-native UX, generative UI, interaction design, design systems, prototyping, front-end development, design leadership, mentorship"
+      },
+      "seeks": {
+        "@type": "Demand",
+        "name": "Staff-level product design role in AI and generative UX",
+        "areaServed": ["Seattle, WA", "Remote", "California", "Canada"]
+      },
       "worksFor": { "@type": "Organization", "name": "Meta Reality Labs" },
       "alumniOf": [
         { "@type": "CollegeOrUniversity", "name": "Capilano University" },
@@ -98,11 +128,11 @@
         <div class="chapter_inner">
           <header class="chapter_meta">
             <span class="chapter_index">01 <span aria-hidden="true">/</span> 06</span>
-            <p class="chapter_kicker">Product Designer · Seattle (for now?)</p>
+            <p class="chapter_kicker">Staff Product Designer · AI &amp; Generative UX · Seattle (for now?)</p>
           </header>
           <div class="chapter_body">
             <h1 id="intro-heading" class="display">Hi there,<br class="display_break"> I'm <span class="display_em">Zach<span class="display_dim">ary</span>&nbsp;<span class="display_shift">Halvorson</span></span></h1>
-            <p class="tagline">A burger-obsessed, Japanese-learning, codes-y designer with 10+ years experience leading with vision, crafting experiences, mentoring others, and shipping products people love.</p>
+            <p class="tagline">A burger-obsessed, Japanese-learning, codes-y Staff Product Designer with 10+ years across AI-native and generative UX — leading with vision, crafting experiences, mentoring others, and shipping products people love.</p>
             <p class="tagline">Here's some of the publicly-available work I'm proud of.</p>
 
             <picture class="intro_photo">
@@ -309,7 +339,7 @@
           </header>
           <div class="chapter_body">
             <h2 id="hello-heading" class="display">Thanks for <span class="display_em">scrolling.</span></h2>
-            <p class="lede">After 5+ years at Meta, wrapping up while on <mark>Agent Harnesses and Generative UI</mark>, I'm currently looking for my next role. If you've got questions, or have something you'd like to build together, <a href="mailto:zacharyhalvorson@me.com">feel free to reach out</a>.</p>
+            <p class="lede">After 5+ years at Meta, wrapping up while on <mark>Agent Harnesses and Generative UI</mark>, I'm currently looking for my next Staff-level product design role in AI and generative UX — open to Seattle, remote, California, or Canada. If you've got questions, or have something you'd like to build together, <a href="mailto:zacharyhalvorson@me.com">feel free to reach out</a>.</p>
             <p class="lede">On the side I'm building <a href="https://github.com/zacharyhalvorson/trip-cams" target="_blank" rel="noopener noreferrer">Trip Cams</a>, a road-trip companion that shows live traffic cameras along your route, and <a href="https://github.com/zacharyhalvorson/Remote-Terminal" target="_blank" rel="noopener noreferrer">Remote Terminal</a>, a zero-setup way to use your Mac from anywhere.</p>
 
             <ul class="socials list-reset">


### PR DESCRIPTION
Surface seniority, AI/generative UX specialization, and location
flexibility across both machine-readable layers and visible prose.

- Enrich JSON-LD Person schema: description, email, homeLocation,
  knowsAbout (skills), hasOccupation, and a seeks/Demand block
  encoding the Staff-level job search and target locations.
- Sharpen <title>, meta description, keywords, robots, and OG/Twitter
  descriptions with AI-native/generative UX keywords.
- Weave Staff Product Designer + AI/generative UX into the intro
  kicker, tagline, and closing lede; add Seattle/remote/CA/Canada
  availability. Voice and layout unchanged.