### PR TITLE
Add first-view hint animation for multi-item stacks

### DIFF
--- a/script.js
+++ b/script.js
@@ -177,10 +177,17 @@
 
   var lightbox = createLightbox();
 
+  // The first multi-item stack gets a one-time "you can leaf through these"
+  // bounce the first time it scrolls into view; later stacks don't repeat it.
+  var hintGiven = false;
   stacks.forEach(function (ul) {
     var items = readItems(ul);
     if (items.length === 1) setupSingle(ul, items);
-    else if (items.length > 1) setupStack(ul, items);
+    else if (items.length > 1) {
+      var wantHint = !hintGiven;
+      hintGiven = true;
+      setupStack(ul, items, wantHint);
+    }
   });
 
   // ---- read media descriptors straight from the DOM ----
@@ -240,7 +247,7 @@
   // ---- multiple items: fanned stack, no visible chrome ----
   // The top card follows your finger as you drag (iMessage-style); release
   // past a threshold to leaf. A plain tap opens the fullscreen carousel.
-  function setupStack(ul, items) {
+  function setupStack(ul, items, wantHint) {
     var lis = items.map(function (it) { return it.el; });
     var active = 0;
 
@@ -427,6 +434,49 @@
       window.addEventListener('resize', fit);
     }
     fit();
+
+    // First-view affordance. The very first stack does a small bounce the
+    // first time it scrolls well into view, signalling that the cards can be
+    // leafed through. It fires once, skips reduced-motion readers, and is
+    // cancelled the moment the reader actually grabs (or keys into) the stack
+    // — no point nudging a card someone's already interacting with.
+    if (wantHint) setupHint();
+    function setupHint() {
+      var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if (reduce || typeof IntersectionObserver === 'undefined') return;
+      var spent = false, timer = null, obs = null;
+      function cancel() {
+        spent = true;
+        clearTimeout(timer);
+        if (obs) { obs.disconnect(); obs = null; }
+        // Kill any in-flight animation so a grab takes over the transform
+        // immediately (the running keyframe would otherwise override the
+        // drag's inline transform).
+        ul.classList.remove('is-hint');
+      }
+      // These run after the drag/keyboard handlers registered earlier, so the
+      // gesture still proceeds; we only tear down the hint.
+      ul.addEventListener('pointerdown', cancel);
+      ul.addEventListener('keydown', cancel);
+      function play() {
+        var front = lis[active];
+        if (!front) return;
+        function done() { ul.classList.remove('is-hint'); front.removeEventListener('animationend', done); }
+        front.addEventListener('animationend', done);
+        ul.classList.add('is-hint');
+      }
+      obs = new IntersectionObserver(function (entries) {
+        if (spent) return;
+        var e = entries[0];
+        if (e.isIntersecting && e.intersectionRatio >= 0.6) {
+          spent = true;
+          obs.disconnect(); obs = null;
+          // Let the card settle in view before it bounces.
+          timer = setTimeout(play, 550);
+        }
+      }, { threshold: [0, 0.6, 1] });
+      obs.observe(ul);
+    }
   }
 
   // ---- shared fullscreen carousel lightbox ----

--- a/style.css
+++ b/style.css
@@ -703,6 +703,23 @@ html.lb-closing .media.is-stack:has(.is-source) .media_item:not(.is-front) {
   transition: opacity 0.36s var(--ease);
 }
 
+/* First-view affordance: the very first stack gives its front card a small
+   bounce the first time it scrolls into view, hinting that the cards can be
+   leafed through. script.js adds .is-hint once (and only if the reader hasn't
+   already grabbed the stack), then removes it when the animation ends. The
+   keyframe nudges the front card aside and springs back, briefly exposing the
+   cards peeking behind. Disabled under reduced motion via the global block. */
+.media.is-stack.is-hint .media_item.is-front {
+  animation: stack-hint 1.1s var(--ease) both;
+}
+@keyframes stack-hint {
+  0%   { transform: translateX(0) rotate(0deg); }
+  28%  { transform: translateX(-30px) rotate(-2.4deg); }
+  52%  { transform: translateX(-6px) rotate(-0.4deg); }
+  70%  { transform: translateX(-16px) rotate(-1.2deg); }
+  100% { transform: translateX(0) rotate(0deg); }
+}
+
 /* ---------- lightbox (fullscreen carousel) ---------- */
 
 /* iOS Safari mis-sizes position:fixed elements — including a modal <dialog>


### PR DESCRIPTION
## Summary

Adds a subtle bounce animation to the first multi-item stack when it scrolls into view, signalling to users that the cards can be leafed through. The hint fires once, respects `prefers-reduced-motion`, and cancels immediately if the user interacts with the stack.

## Changes

- **script.js**: 
  - Track whether a hint has been shown via `hintGiven` flag; only the first multi-item stack receives the hint
  - Pass `wantHint` parameter to `setupStack()` to conditionally enable the affordance
  - Implement `setupHint()` function that:
    - Uses `IntersectionObserver` to detect when the stack scrolls 60%+ into view
    - Plays a 1.1s bounce animation on the front card after a 550ms settle delay
    - Cancels the hint if the user grabs the stack (`pointerdown`) or navigates via keyboard (`keydown`)
    - Respects `prefers-reduced-motion` and degrades gracefully if `IntersectionObserver` is unavailable

- **style.css**:
  - Add `.is-hint` class styling for `.media.is-stack.is-hint .media_item.is-front`
  - Define `@keyframes stack-hint` animation: a 1.1s easing that nudges the front card left and rotates it slightly, briefly exposing the cards behind, then springs back to rest
  - Animation is disabled under `prefers-reduced-motion` via the global block

## Implementation Details

- The hint is a progressive enhancement: it requires `IntersectionObserver` and respects reduced-motion preferences
- The animation is cancelled the moment the user interacts (drag or keyboard), ensuring no visual conflict with user input
- The 550ms delay before animation allows the card to settle in the viewport before the bounce, improving the visual effect
- The hint only fires once per page load, on the first multi-item stack, to avoid repetitive nudging

https://claude.ai/code/session_018QsdkyXFr2TWYvmiUumtN2