### PR TITLE
Fix cropped case-study rail thumbnails on /work

### DIFF
--- a/work/index.html
+++ b/work/index.html
@@ -489,17 +489,20 @@
 
     // Shadow-root level: float the deck's slide navigator (`.rail`) like
     // Keynote — inset, rounded, a translucent tint slightly darker than the
-    // canvas behind it. The deck positions its stage with an inline `left`,
-    // so we override the stage's left/width directly (the `--deck-rail-w`
-    // variable doesn't drive it). Toggling `.rail-off` on the host slides the
+    // canvas behind it. The deck positions its stage with an inline `left`, so
+    // we override the stage's left/width directly. Toggling `.rail-off` on the host slides the
     // rail off-screen and expands the stage to full width — the deck
     // re-centers the slide into the freed space — both transitioned.
     // Injected into deck-stage's (open) shadow root; document CSS can't reach it.
     var EASE = "cubic-bezier(0.2,0.7,0.2,1)";
-    var STAGE_LEFT = "205px"; // clears the floated rail (left 9 + width 178 + gap)
+    // The deck bakes each thumbnail's scale for a rail of --deck-rail-w wide.
+    // Match that width or the previews render larger than the frame and crop
+    // on the right/bottom. Tracking the var keeps them fitted across exports.
+    var RAIL_W = "var(--deck-rail-w, 188px)";
+    var STAGE_LEFT = "calc(9px + " + RAIL_W + " + 18px)"; // clears the floated rail (left + width + gap)
     var RAIL_CSS =
       ".rail{top:14px !important;bottom:14px !important;left:9px !important;" +
-      "height:auto !important;width:178px !important;border:none !important;" +
+      "height:auto !important;width:" + RAIL_W + " !important;border:none !important;" +
       "border-radius:16px !important;padding:10px !important;" +
       "background:rgba(0,0,0,0.06) !important;" +
       "box-shadow:0 4px 18px rgba(0,0,0,0.08) !important;" +
@@ -715,7 +718,9 @@
     // rail (it reclaims ~the stage offset, less a small margin).
     function fillScaleFor(ds) {
       var w = ds.getBoundingClientRect().width;
-      return w > 280 ? (w - 40) / (w - 205) : 1;
+      var railW = parseFloat(getComputedStyle(ds).getPropertyValue("--deck-rail-w")) || 188;
+      var stageLeft = 9 + railW + 18; // mirror STAGE_LEFT (rail inset + width + gap)
+      return w > 280 ? (w - 40) / (w - stageLeft) : 1;
     }
 
     // Toggle the slide navigator across all loaded decks, keeping each deck's


### PR DESCRIPTION
## What

Stops the slide-navigator thumbnails on `/work` from clipping on the right (and bottom) edge. Affected every thumbnail in both decks; the Meta Ray-Ban Display "explorations" slide (the 4-card row) made it most visible.

## Why

The deck export bakes a **fixed inline `transform: scale(0.0744792)`** onto each thumbnail preview, computed for the rail width it reserves via `--deck-rail-w` (`188px`). That renders each preview at **143×80px**.

Our Keynote-style rail redesign had narrowed the floated `.rail` to `178px`, which shrank each thumbnail frame to **134×75px**. The baked preview (143px) then overflowed the smaller frame and got clipped by the frame's `overflow: hidden`.

## How

Three changes in `work/index.html` so our redesigned rail occupies exactly the footprint the deck bakes thumbnails for:

- **Rail width tracks the deck's own variable**: `width: var(--deck-rail-w, 188px)` instead of hardcoded `178px`. Self-healing — if a future export changes the deck's rail metrics, our rail follows and thumbnails stay fitted.
- **`STAGE_LEFT`** recomputed as `calc(9px + var(--deck-rail-w,188px) + 18px)` so the slide stage still clears the (slightly wider) rail with the same 18px gap.
- **`fillScaleFor()`** reads `--deck-rail-w` to derive the rail-off fill scale, replacing the stale hardcoded `205`.

The tight left inset (`left: 9px`) is unchanged; the rail is only ~10px wider.

## Verification

- Measured across **all 24 thumbnails in both decks** (rayban-display + rayban-meta): `maxOverflowX` and `maxOverflowY` are now **0** — zero clipping.
- Visual check confirms every thumbnail fits with a clean right margin.
- Rail show/hide toggle still works; stage offset (`215px`) and fill-scale (`1.3676`) resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)