### PR TITLE
Add shareable link that skips the /work passphrase gate

### DIFF
--- a/work/index.html
+++ b/work/index.html
@@ -465,6 +465,12 @@
     var PASS_HASH = "798147886b5d89368a69437e162aa859d0e3569579576c099d3f1ac8a75e8b55";
     var UNLOCK_KEY = "work-unlocked-v1";
 
+    /* A shareable link that skips the passphrase entirely:
+       /work#hotdocs-from-heaven. Arriving with this fragment unlocks just
+       like a correct entry and persists the unlock (below), so the link is
+       only ever needed once. Same deterrent-not-security caveat applies. */
+    var BYPASS_HASH = "hotdocs-from-heaven";
+
     /* Styles injected into each export to theme the slide-PLAYER chrome,
        not the slides. Injected from the parent (same-origin) because the
        bundler rebuilds the document and wipes anything shipped inside it.
@@ -817,10 +823,16 @@
       if (!gateError.hidden) gateError.hidden = true;
     });
 
-    // Already unlocked on this device? Skip the gate (persists across
-    // navigations, tabs, and return visits).
+    // Already unlocked on this device, or arriving via the shareable bypass
+    // link (/work#hotdocs-from-heaven)? Skip the gate. localStorage persists
+    // the unlock across navigations, tabs, and return visits, so the
+    // passphrase (or the link) is only ever needed once.
     var unlocked = false;
     try { unlocked = localStorage.getItem(UNLOCK_KEY) === "1"; } catch (_) {}
+    if (location.hash.replace(/^#/, "").toLowerCase() === BYPASS_HASH) {
+      try { localStorage.setItem(UNLOCK_KEY, "1"); } catch (_) {}
+      unlocked = true;
+    }
     if (unlocked) {
       reveal();
     } else {


### PR DESCRIPTION
## What

Adds a shareable link that bypasses the `/work` passphrase gate: visiting **`/work#hotdocs-from-heaven`** unlocks the case-study reader directly, with no passphrase entry.

## Why

So access can be handed out via a single clickable link instead of asking people to type the passphrase.

## How it works

- A new `BYPASS_HASH` token (`hotdocs-from-heaven`) is checked on load, alongside the existing `localStorage` unlock check.
- Arriving with that fragment is treated exactly like a correct passphrase entry: it sets the same `localStorage["work-unlocked-v1"]` flag and reveals the reader.
- The reader then rewrites the URL fragment to the active case slug (e.g. `#rayban-meta`), so the secret token doesn't linger in the address bar.
- Because it reuses the existing unlock flag, the link — like the passphrase — is only needed **once** per device/browser. Return visits and bare `/work/` loads skip the gate.

Still a client-side deterrent, not real security — same caveat as the existing gate.

## Verified in a local preview

| Scenario | Result |
|---|---|
| Fresh visit to `/work#hotdocs-from-heaven` | Gate skipped, reader shown, unlock persisted, URL cleaned to `#rayban-meta` |
| Return to bare `/work/` afterward | Gate still skipped (persisted unlock) |
| Fresh visitor, no stored unlock, no token | Passphrase prompt shown as before (normal flow unchanged) |

## Reviewer notes

- **`hotdocs` vs `hotdogs`:** the link uses `hotdocs-from-heaven` as requested (reads as a "hot docs" pun); the passphrase itself remains "hotdogs from heaven". Easy to realign if preferred.
- **Edge case left alone:** if a visitor is already sitting on the gate and edits *only* the URL fragment (same path, no reload), the bypass won't fire since the page doesn't reload. The intended flow — opening the shared link as a fresh navigation — is a full load and works. Avoided a `hashchange` listener to keep the gate script minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)