### PR TITLE
Polish /work gate (hotdog unlock affordance) and link it from the home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@
           </header>
           <div class="chapter_body">
             <h2 id="hello-heading" class="display">Thanks for <span class="display_em">scrolling.</span></h2>
-            <p class="lede">After 5+ years at Meta, wrapping up while on <mark>Agent Harnesses and Generative UI</mark>, I'm currently looking for my next role. If you've got questions, or if you want to see more of my work, <a href="mailto:zacharyhalvorson@me.com">feel free to reach out</a>.</p>
+            <p class="lede">After 5+ years at Meta, wrapping up while on <mark>Agent Harnesses and Generative UI</mark>, I'm currently looking for my next role. If you've got questions, or if you want to <a href="/work/">see more of my work</a>, <a href="mailto:zacharyhalvorson@me.com">feel free to reach out</a>.</p>
             <p class="lede">On the side I'm building <a href="https://github.com/zacharyhalvorson/trip-cams" target="_blank" rel="noopener noreferrer">Trip Cams</a>, a road-trip companion that shows live traffic cameras along your route, and <a href="https://github.com/zacharyhalvorson/Remote-Terminal" target="_blank" rel="noopener noreferrer">Remote Terminal</a>, a zero-setup way to use your Mac from anywhere.</p>
 
             <ul class="socials list-reset">

--- a/script.js
+++ b/script.js
@@ -179,7 +179,17 @@
 
   // The first multi-item stack gets a one-time "you can leaf through these"
   // bounce the first time it scrolls into view; later stacks don't repeat it.
-  var hintGiven = false;
+  // Once it has played, the fact is stored for the rest of the browsing
+  // session, so navigating away and back doesn't replay it. sessionStorage
+  // clears when the tab/window closes, so a brand-new session sees it again.
+  var HINT_KEY = 'media-hint-seen-v1';
+  function hintSeen() {
+    try { return sessionStorage.getItem(HINT_KEY) === '1'; } catch (e) { return false; }
+  }
+  function markHintSeen() {
+    try { sessionStorage.setItem(HINT_KEY, '1'); } catch (e) {}
+  }
+  var hintGiven = hintSeen();
   stacks.forEach(function (ul) {
     var items = readItems(ul);
     if (items.length === 1) setupSingle(ul, items);
@@ -464,6 +474,7 @@
         function done() { ul.classList.remove('is-hint'); front.removeEventListener('animationend', done); }
         front.addEventListener('animationend', done);
         ul.classList.add('is-hint');
+        markHintSeen();
       }
       obs = new IntersectionObserver(function (entries) {
         if (spent) return;

--- a/work/index.html
+++ b/work/index.html
@@ -46,6 +46,12 @@
       --rule: rgba(0, 0, 0, 0.08);
       --highlight: #fff3d6;
       --highlight-deep: #f3e5b8;
+      /* Green siblings of the warm highlights — same soft, muted weight,
+         used for the "correct passphrase" success state. -green mirrors
+         --highlight (soft, for the glow); -green-deep mirrors
+         --highlight-deep (the border + the button fill). */
+      --highlight-green: #e9f6da;
+      --highlight-green-deep: #bfe3a6;
       --link: #0066cc;
       --link-hover: #003f80;
 
@@ -69,6 +75,8 @@
         --rule: rgba(255, 255, 255, 0.1);
         --highlight: #4a3a16;
         --highlight-deep: #6b5520;
+        --highlight-green: #313f1c;
+        --highlight-green-deep: #4a7d2c;
         --link: #7cc4ff;
         --link-hover: #b3dcff;
 
@@ -231,6 +239,9 @@
       height: 100%;
       border: 0;
       visibility: hidden;
+      /* Canvas colour until the export paints, so a freshly-revealed frame
+         never flashes white (most visible in dark mode) during the unlock. */
+      background: var(--base);
     }
     .frame.-active {
       visibility: visible;
@@ -302,6 +313,12 @@
       border-color: var(--highlight-deep);
       box-shadow: 0 0 0 3px var(--highlight);
     }
+    /* Once the passphrase is correct, the input's focus glow goes green to
+       match the success button. */
+    .gate_field:has(.gate_submit.-ready) input:focus {
+      border-color: var(--highlight-green-deep);
+      box-shadow: 0 0 0 3px var(--highlight-green);
+    }
 
     .gate_submit {
       position: absolute;
@@ -318,10 +335,46 @@
       border: none;
       border-radius: 50%;
       cursor: pointer;
-      transition: filter 140ms var(--ease);
+      /* Ease the gold->green fill so the success state arrives, not flashes. */
+      transition: background 220ms var(--ease), filter 140ms var(--ease);
     }
     .gate_submit:hover { filter: brightness(0.94); }
-    .gate_submit svg { width: 1.05rem; height: 1.05rem; }
+
+    /* The arrow and the hotdog share one grid cell so they cross-fade in
+       place: the arrow eases out as the dog pops in, with no empty-circle
+       flash in between. */
+    .gate_submit_arrow,
+    .gate_submit_dog {
+      grid-area: 1 / 1;
+      transition: opacity 180ms var(--ease), transform 180ms var(--ease);
+    }
+    .gate_submit_arrow { width: 1.05rem; height: 1.05rem; }
+    .gate_submit_dog {
+      font-size: 1.15rem;
+      line-height: 1;
+      opacity: 0;
+      transform: scale(0.4);
+    }
+    /* Once the typed passphrase is correct, the arrow gives way to a hotdog
+       that pops in — a playful "you got it" before they even hit enter. */
+    .gate_submit.-ready { background: var(--highlight-green-deep); }
+    .gate_submit.-ready .gate_submit_arrow { opacity: 0; transform: scale(0.4); }
+    .gate_submit.-ready .gate_submit_dog {
+      opacity: 1;
+      transform: none;
+      animation: dogpop 0.42s var(--ease);
+    }
+    @keyframes dogpop {
+      0%   { transform: scale(0) rotate(-30deg); opacity: 0; }
+      55%  { transform: scale(1.35) rotate(8deg); opacity: 1; }
+      75%  { transform: scale(0.9) rotate(-5deg); }
+      100% { transform: scale(1) rotate(0); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .gate_submit_arrow,
+      .gate_submit_dog { transition: none; }
+      .gate_submit.-ready .gate_submit_dog { animation: none; }
+    }
 
     .gate_form { position: relative; }
     /* The error sits just above the input, positioned absolutely so showing
@@ -351,8 +404,16 @@
       .gate_field.-wrong { animation: none; }
     }
 
-    /* Slow the pill morph a touch for a smoother settle. */
-    ::view-transition-group(authpill) { animation-duration: 360ms; }
+    /* Keep the unlock buttery: the pill->tab-bar morph and the whole-page
+       crossfade share one duration and the site easing, so neither races
+       ahead of the other into a flash. */
+    ::view-transition-group(authpill),
+    ::view-transition-group(root),
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+      animation-duration: 360ms;
+      animation-timing-function: var(--ease);
+    }
 
     .gate_help {
       margin: 1.4rem auto 0;
@@ -404,10 +465,11 @@
             autocorrect="off"
             spellcheck="false">
           <button type="submit" class="gate_submit" aria-label="Enter">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <svg class="gate_submit_arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M5 12h14"></path>
               <path d="M13 6l6 6-6 6"></path>
             </svg>
+            <span class="gate_submit_dog" aria-hidden="true">&#x1F32D;</span>
           </button>
         </div>
       </form>
@@ -531,6 +593,7 @@
     var gateField = document.querySelector(".gate_field");
     var gateInput = document.getElementById("gate-input");
     var gateError = document.getElementById("gate-error");
+    var gateSubmit = gateForm.querySelector(".gate_submit");
     var app = document.getElementById("app");
     var selectEl = document.getElementById("case-select");
     var railToggle = document.getElementById("rail-toggle");
@@ -819,8 +882,21 @@
       });
     });
 
+    // Swap the arrow for a popping hotdog the instant the typed passphrase
+    // is correct — a little "you got it" tell before they submit. Hashing is
+    // async, so ignore a result if the field changed while it was computing.
+    function refreshDog() {
+      var value = gateInput.value.trim().toLowerCase();
+      if (!value) { gateSubmit.classList.remove("-ready"); return; }
+      sha256Hex(value).then(function (hex) {
+        if (gateInput.value.trim().toLowerCase() !== value) return;
+        gateSubmit.classList.toggle("-ready", hex === PASS_HASH);
+      });
+    }
+
     gateInput.addEventListener("input", function () {
       if (!gateError.hidden) gateError.hidden = true;
+      refreshDog();
     });
 
     // Already unlocked on this device, or arriving via the shareable bypass


### PR DESCRIPTION
## What

Three related touches to the portfolio's `/work` case-study reader and the home page.

### Home page
- The **"see more of my work"** phrase in the closing colophon now links to `/work/`.
- It points at the canonical trailing-slash URL on purpose: the case-study `<iframe>`s use relative paths (`rayban-meta/`), which only resolve when the page URL ends in `/`. Linking to `/work` (no slash) made them resolve to `/rayban-meta/` and 404 locally, before GitHub Pages' redirect adds the slash in production.

### /work passphrase gate
- **Hotdog unlock affordance:** when the typed passphrase is correct, the submit arrow swaps for a 🌭 that pops in, a little "you got it" tell before the visitor even hits enter. Detection reuses the existing SHA-256 hash, so it lights up exactly when correct (and reverts if they edit the text).
- **Green success accent:** added `--highlight-green` / `--highlight-green-deep` as siblings of the existing warm `--highlight` / `--highlight-deep` palette (soft + deep, both light/dark). The button fill and the input's focus glow both use them, so they match.
- **Smoothed two flashes** the gate had:
  - Eased the gold to green fill, and cross-fade the arrow and hotdog in a single grid cell so there's no empty-circle frame between them.
  - Gave the `<iframe>` a canvas-colored background so a freshly revealed frame doesn't flash white before the export paints (worst in dark mode).
  - Synced the unlock pill morph with the whole-page crossfade on one duration + the site easing, so neither races ahead.

### Home page media stacks
- The one-time "you can leaf through these" bounce hint now records in `sessionStorage` once it plays, so navigating away and back within a session doesn't replay it. A brand-new session (tab/window closed) still sees it once.

## Notes for reviewer
- All progressive-enhancement / no-JS, dark-mode, and reduced-motion behavior is preserved: the hotdog emoji is `aria-hidden` (button keeps its "Enter" label), reduced-motion disables the icon transitions and pop, and the success styling falls back gracefully where `:has()` isn't supported.
- This branch is cut fresh from `master`; the earlier `work-bypass-link` work was already merged in #42.

## Verification
Verified in the local preview across light/dark and mobile/desktop: the hotdog appears only on the exact passphrase, the green accent matches between button and input glow in both schemes, the iframe loads via `/work/` with no 404, and the bounce hint persists across reloads within a session. No console errors.