### PR TITLE
Rename "Experience" section to "Professional Experience"

### DIFF
--- a/resume/index.html
+++ b/resume/index.html
@@ -238,7 +238,7 @@
       technical range to design and build AI-native experiences firsthand.
     </p>
 
-    <h2>Experience</h2>
+    <h2>Professional Experience</h2>
 
     <section class="job">
       <h3 class="job_title">


### PR DESCRIPTION
## Summary
Updated the section heading in the resume/colophon from "Experience" to "Professional Experience" for greater clarity and specificity.

## Changes
- Changed `<h2>Experience</h2>` to `<h2>Professional Experience</h2>` in the colophon section of `index.html`

## Details
This is a minor content update that improves the semantic clarity of the resume section. The heading now more explicitly indicates that this section covers professional work history, which aligns with the site's purpose as a personal portfolio and resume.

https://claude.ai/code/session_017qmDxvQDPeU3SDqpWFQBHt