### PR TITLE
Fix work-deck keyboard nav + fullscreen, and strip editor-only toolchain from published decks

### DIFF
--- a/work/README.md
+++ b/work/README.md
@@ -23,10 +23,12 @@ design** and dropped in at `work/<slug>/`.
 
 A raw export ships every slide `<video>` with `autoplay` and no `preload`, and
 every slide is in the DOM at once — so the browser eagerly downloads **all** the
-clips on first load (tens of MB), most for slides nobody scrolls to. Two pieces
-fix this:
+clips on first load (tens of MB), most for slides nobody scrolls to. It also
+ships an in-browser **edit-mode toolchain** (React + Babel-standalone from a CDN
+that transform the `deck-tweaks` / `tweaks-panel` authoring panel live) that no
+visitor needs. Two pieces fix this:
 
-- **`optimize-deck.mjs`** (run per export) does two things to each deck:
+- **`optimize-deck.mjs`** (run per export) does three things to each deck:
   - rewrites every `<video>` to `preload="none"` with no `autoplay`, and gives
     each clip a **poster** still (a frame extracted with `ffmpeg`). The poster
     is what shows on the slide and in the navigator rail thumbnail before/while
@@ -35,6 +37,14 @@ fix this:
     links it render-blocking, which stalls the first paint on a round-trip to
     `fonts.googleapis.com`). The deck defaults to the system font stack with
     `font-display: swap`, so the webfont can swap in lazily.
+  - **strips the edit-mode toolchain** — the `<script type="text/babel">` JSX
+    tags plus the React/ReactDOM/Babel-standalone CDN scripts that exist only to
+    run them. That panel only mounts inside the design editor; at view time it
+    just re-applies the theme/font already baked into the export's `<html>`, so
+    it's pure dead weight — and the site's only third-party-CDN dependency. The
+    deck's own player (`deck-stage.js` / `image-slot.js`) is vanilla and is left
+    untouched. Bundler-style exports inline these behind a manifest and are
+    detected and skipped, same as their media.
 - **The reader shell** (`work/index.html`, automatic for every deck) plays only
   the **on-screen slide's** videos and pauses the rest. So a clip's bytes are
   pulled only when its slide is actually shown, then stay buffered for instant

--- a/work/index.html
+++ b/work/index.html
@@ -544,6 +544,10 @@
       // stays crisp). `--fill-scale` is computed in JS from the deck width.
       "deck-stage.rail-off .slide{transform:scale(var(--fill-scale,1)) !important;" +
       "transform-origin:center !important}" +
+      // In fullscreen the deck fits the canvas to the full screen itself, so the
+      // rail-off fill-scale (computed for the embedded width) would over-scale
+      // the slide and overflow. Drop it while data-fs is set.
+      "deck-stage[data-fs] .slide{transform:none !important}" +
       "@media (prefers-color-scheme:dark){" +
       "html,body{background:#1c1b19 !important}" +
       "deck-stage{background:#1c1b19 !important}" +
@@ -610,6 +614,15 @@
       "visibility:hidden !important;pointer-events:none !important;" +
       "transition:transform 360ms " + EASE + ",visibility 0s linear 360ms !important}" +
       ":host(.rail-off) .stage{left:0 !important;width:100% !important}" +
+      // Fullscreen: the deck collapses its rail to a hover-peek strip and its
+      // _fit() reclaims the full width (_railWidth() returns 0 while data-fs is
+      // set), so the reserved rail column has to step aside or the slide sits
+      // offset on the black presentation canvas. Keyed on the deck's own
+      // data-fs attribute, which it sets for both standard and webkit
+      // fullscreen. Snap (no transition) so it doesn't race the browser's
+      // fullscreen zoom while _fit re-scales the canvas.
+      ":host([data-fs]) .stage{left:0 !important;width:100% !important;" +
+      "transition:none !important}" +
       "@media (prefers-color-scheme:dark){" +
       ".rail{background:rgba(0,0,0,0.28) !important;box-shadow:0 6px 22px rgba(0,0,0,0.45) !important}" +
       ".rail:hover::-webkit-scrollbar-thumb{background:rgba(255,255,255,0.30) !important}" +
@@ -692,6 +705,13 @@
         frame.id = "frame-" + c.slug;
         frame.title = c.label + " case study";
         frame.setAttribute("loading", "lazy");
+        // The deck's navigator has a fullscreen toggle that calls
+        // requestFullscreen() on an element *inside* the iframe; the Fullscreen
+        // API gates that behind the frame's permission, so without this it's
+        // flaky (works only in browsers lenient about same-origin frames). Set
+        // both the modern allow= and the legacy attribute for coverage.
+        frame.setAttribute("allow", "fullscreen");
+        frame.setAttribute("allowfullscreen", "");
         frame.dataset.src = c.src; // lazy: real src set on first selection
         stage.appendChild(frame);
         frames[c.slug] = frame;

--- a/work/index.html
+++ b/work/index.html
@@ -734,6 +734,11 @@
         history.replaceState(null, "", "#" + slug);
       }
       document.title = labelFor(slug) + " — Zachary Halvorson";
+      // The export only receives keyboard nav while its iframe is the focused
+      // frame. Hand focus to the live deck on load and on every case switch so
+      // arrow / Page / Space / Home-End work immediately — without this the
+      // shell keeps focus and keys do nothing until you click into the slide.
+      try { frames[slug].focus({ preventScroll: true }); } catch (e) {}
     }
 
     // Load an export iframe once; call onReady when it has rendered (or right
@@ -1084,6 +1089,37 @@
     });
     window.addEventListener("pointerdown", function () {
       document.body.classList.remove("-kbd");
+    });
+
+    // activate() hands focus to the deck, but focus can drift back to the
+    // shell chrome (clicking the home or sidebar button, the dropdown). When
+    // it has, forward the export's navigation keys to the active case so they
+    // keep working without re-clicking the slide. Re-dispatch into the iframe
+    // so the first press counts, then hand focus over for subsequent keys.
+    var DECK_NAV_KEYS = {
+      ArrowLeft: 1, ArrowRight: 1, PageUp: 1, PageDown: 1,
+      Home: 1, End: 1, " ": 1, Spacebar: 1
+    };
+    window.addEventListener("keydown", function (e) {
+      if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (!DECK_NAV_KEYS[e.key]) return;
+      var ae = document.activeElement;
+      if (ae) {
+        var tag = ae.tagName;
+        // Leave focused controls alone: the case dropdown, gate input, links.
+        if (ae === selectEl || ae.isContentEditable ||
+            tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" ||
+            tag === "BUTTON" || tag === "A") return;
+      }
+      var frame = active && frames[active];
+      if (!frame || !frame.contentWindow || ae === frame) return;
+      try {
+        frame.contentWindow.dispatchEvent(
+          new KeyboardEvent("keydown", { key: e.key, code: e.code })
+        );
+        frame.focus({ preventScroll: true });
+        e.preventDefault();
+      } catch (err) {}
     });
 
     function defaultSlug() {

--- a/work/index.html
+++ b/work/index.html
@@ -918,7 +918,7 @@
               ds.classList.add("rail-anim");
               setupRail(frame, ds);
             }
-            if (ds) { applyRailToDeck(ds); setupVideoDefer(frame, ds); }
+            if (ds) { applyRailToDeck(ds); setupVideoDefer(frame, ds); setupKeyNav(frame, ds); }
           }
         } catch (e) { /* not ready yet */ }
         if (tries > 50) clearInterval(iv); // ~5s covers unpack + first paint
@@ -962,6 +962,29 @@
         });
         sync();
       } catch (e) { /* cross-origin / not ready — videos rest on posters */ }
+    }
+
+    // The deck's own keymap covers Left/Right, PageUp/Down, Space and Home/End,
+    // but not the arrow Up/Down keys people also reach for. Teach each export
+    // those from the shell (the deck is regenerated on every re-export, so this
+    // can't live in it): translate Down→next, Up→prev by re-dispatching the
+    // keys the deck already handles. Listens on the deck's own window, so it
+    // fires both for a real press while the deck has focus AND for the shell
+    // forwarder's synthetic press when focus is on the chrome — one path, both.
+    function setupKeyNav(frame, ds) {
+      if (ds.dataset.keyNav) return;
+      ds.dataset.keyNav = "1";
+      try {
+        var win = frame.contentWindow;
+        win.addEventListener("keydown", function (e) {
+          if (e.metaKey || e.ctrlKey || e.altKey) return;
+          var to = e.key === "ArrowDown" ? "ArrowRight"
+                 : e.key === "ArrowUp" ? "ArrowLeft" : null;
+          if (!to) return;
+          e.preventDefault();
+          win.dispatchEvent(new win.KeyboardEvent("keydown", { key: to }));
+        });
+      } catch (e) { /* cross-origin / not ready — Up/Down simply do nothing */ }
     }
 
     // The fill scale grows the slide to fill the width freed by hiding the
@@ -1097,8 +1120,8 @@
     // keep working without re-clicking the slide. Re-dispatch into the iframe
     // so the first press counts, then hand focus over for subsequent keys.
     var DECK_NAV_KEYS = {
-      ArrowLeft: 1, ArrowRight: 1, PageUp: 1, PageDown: 1,
-      Home: 1, End: 1, " ": 1, Spacebar: 1
+      ArrowLeft: 1, ArrowRight: 1, ArrowUp: 1, ArrowDown: 1, PageUp: 1,
+      PageDown: 1, Home: 1, End: 1, " ": 1, Spacebar: 1
     };
     window.addEventListener("keydown", function (e) {
       if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.altKey) return;

--- a/work/optimize-deck.mjs
+++ b/work/optimize-deck.mjs
@@ -17,6 +17,13 @@
 //     rail thumbnails (the rail falls back to the poster when it can't grab a
 //     live frame).
 //
+// It also strips the in-browser JSX edit-mode toolchain a raw export ships
+// (React + Babel-standalone from a CDN, plus the deck-tweaks / tweaks-panel
+// authoring panel). That panel only mounts inside the design editor; at view
+// time it just re-applies the theme/font already baked into the export's
+// <html>, so for visitors it's pure dead weight — and the site's only
+// third-party-CDN dependency. See stripEditorScripts.
+//
 // The playback half is automatic for every deck (handled by the shell), so the
 // ONLY per-export step is running this script. Re-run it after every re-export.
 //
@@ -125,6 +132,39 @@ function rewriteFontLinks(html) {
   return { html: out, count };
 }
 
+// Strip the in-browser JSX edit-mode toolchain from a published export. A raw
+// export ships a "Tweaks" authoring panel (deck-tweaks.jsx / tweaks-panel.jsx)
+// plus the React, ReactDOM, and Babel-standalone CDN scripts that transform and
+// run it in the browser. The panel only mounts inside the design editor (it
+// listens for __activate_edit_mode) and at view time merely re-applies the
+// theme/font defaults already on the export's <html>, so it's dead weight for
+// visitors — and the only third-party-CDN dependency on the site. Drop the
+// <script type="text/babel"> JSX tags and the React/Babel loaders that exist
+// solely to serve them; the deck's own player (deck-stage.js / image-slot.js)
+// is vanilla and untouched.
+//
+// Matches only *empty-bodied* <script ...></script> tags (every target is one),
+// so it can never span the content of a bundler-style export, whose React/Babel
+// refs live as escaped strings inside a __bundler/* manifest — those have a body
+// and are left alone, matching the "bundles are already local" stance below.
+function stripEditorScripts(html) {
+  const isEditorLoader = (open) =>
+    /\bsrc\s*=\s*["'][^"']*(react(-dom)?[@.]|@babel\/standalone|babel(\.min)?\.js)/i.test(open);
+  let count = 0;
+  const out = html.replace(
+    /[ \t]*<script\b([^>]*)>\s*<\/script>[ \t]*\r?\n?/gi,
+    (whole, attrs) => {
+      const open = "<script" + attrs + ">";
+      if (/\btype\s*=\s*["']?text\/babel/i.test(open) || isEditorLoader(open)) {
+        count++;
+        return "";
+      }
+      return whole;
+    }
+  );
+  return { html: out, count };
+}
+
 function ffmpegPoster(videoAbs, posterAbs) {
   execFileSync(
     "ffmpeg",
@@ -141,6 +181,10 @@ function processDeck(indexPath) {
   // Render-blocking webfont CSS → async (independent of whether there's video).
   const fonts = rewriteFontLinks(html);
   html = fonts.html;
+
+  // Drop the editor-only React/Babel/tweaks-panel scripts (view-time dead weight).
+  const editors = stripEditorScripts(html);
+  html = editors.html;
 
   let rewritten = 0, postersMade = 0, skipped = 0;
   const seen = new Set();
@@ -178,10 +222,11 @@ function processDeck(indexPath) {
     }
   }
 
-  if (rewritten || postersMade || fonts.count) {
+  if (rewritten || postersMade || fonts.count || editors.count) {
     writeFileSync(indexPath, html);
     const bits = [`${rewritten} tag(s) rewritten`, `${postersMade} poster(s) generated`];
     if (fonts.count) bits.push(`${fonts.count} font link(s) made async`);
+    if (editors.count) bits.push(`${editors.count} editor script(s) stripped`);
     console.log(`✓ ${slug}: ${bits.join(", ")}${skipped ? `, ${skipped} skipped` : ""}`);
   } else {
     console.log(`· ${slug}: already optimized${skipped ? ` (${skipped} non-file src skipped)` : ""}`);

--- a/work/rayban-meta/index.html
+++ b/work/rayban-meta/index.html
@@ -1156,11 +1156,6 @@
 <script src="deck-stage.js"></script>
 <script src="image-slot.js"></script>
 
-<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
-<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
-<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
-<script type="text/babel" src="tweaks-panel.jsx"></script>
-<script type="text/babel" src="deck-tweaks.jsx"></script>
 
 <template id="__bundler_thumbnail" data-bg-color="#0e6b5e">
   <svg viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Four fixes to the `/work` case-study reader, all at the shell/pipeline layer so the **export → drop in → run `optimize-deck.mjs`** import workflow stays a clean file swap (no rewriting the iframed deck's player).

## 1. Keyboard nav didn't work until you clicked into a slide

Each case study is an export embedded as a same-origin `<iframe>`, and the deck registers its arrow / Page / Space / Home-End handler on **its own iframe window**. The reader shell holds focus on load, so those keys went to the shell and did nothing until you clicked into the slide.

- `activate()` now hands focus to the live deck on load and on every case switch.
- A shell-level forwarder re-dispatches the deck's nav keys into the active iframe when focus drifts back to the chrome, then hands focus over so subsequent presses route natively. Guarded to leave the case dropdown, gate input, links, and buttons alone.

## 2. Up/Down arrow keys now navigate (Down = next, Up = prev)

The deck's keymap never covered Up/Down. Since the deck is regenerated on every re-export, the durable fix lives in the shell: a `setupKeyNav` translator injected into each iframe (alongside the existing theme/video/rail injection) maps Down→next, Up→prev by re-dispatching the keys the deck already handles. Listens on the deck's own window, so it covers both a real press while the deck has focus and the shell forwarder's synthetic press when focus is on the chrome. The dropdown keeps native Up/Down.

## 3. Fullscreen put the slide off-centre on a black canvas

Two causes, both fixed shell-side (so it covers both exports):

- The shell reserves a left column for its floating rail by forcing `.stage{left;width}` into the deck's shadow root. In fullscreen the deck collapses its rail and its `_fit()` reclaims the full width (`_railWidth()` returns 0 while `data-fs` is set), but the shell's offset stayed — so the slide sat right-of-centre and overflowed. Now zeroed while the deck's own `data-fs` attribute is set (covers standard + webkit fullscreen), with the rail-off fill-scale dropped there too.
- The deck's fullscreen button calls `requestFullscreen()` on an element **inside** the iframe, which the Fullscreen API gates behind the frame's permission. The iframe had none, so it only worked in browsers lenient about same-origin frames. Now grants `allow="fullscreen"` + `allowfullscreen`.

## 4. Strip the editor-only React/Babel toolchain from published decks

A raw export ships an in-browser edit-mode "Tweaks" panel (`deck-tweaks.jsx` / `tweaks-panel.jsx`) plus the **React + ReactDOM + Babel-standalone CDN scripts** that transform and run it live. That panel only mounts inside the design editor (it listens for `__activate_edit_mode`); at view time it just re-applies the theme/font already baked into the export's `<html>`. For visitors it's pure dead weight — and the site's only third-party-CDN dependency.

`optimize-deck.mjs` now strips those `<script>` tags on publish (new `stripEditorScripts`). It matches **only empty-bodied `<script></script>` tags**, so it can never span a bundler-style export's escaped `__bundler/*` manifest content — those are left alone, like their inlined media. The deck's own player (`deck-stage.js` / `image-slot.js`) is vanilla and untouched. Idempotent; re-run after every re-export. Applied here: rayban-meta loses 5 scripts; rayban-display is bundled and unaffected.

## Verification
- **Keyboard:** on load, focus lands on the active deck; Left/Right and Up/Down advance/retreat in both focus states; focused dropdown keeps native arrow behavior; no console errors.
- **Fullscreen:** simulating the deck's `data-fs` state, the stage snaps to `left:0`/`width:100%` and the slide centres exactly (cx = viewport centre, cy ≈ centre); fill-scale neutralized; `fullscreenEnabled` is now `true` inside the frame.
- **Strip:** served HTML confirmed stripped 4 ways; both player scripts define `deck-stage` + `image-slot` cleanly with no missing React/Babel dependency; the stripped deck renders fully; `optimize-deck.mjs --all` is idempotent and leaves the bundled deck untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)