### PR TITLE
Fix double-tap on body links and random landing spot on in-page nav

### DIFF
--- a/script.js
+++ b/script.js
@@ -41,6 +41,34 @@
   // pick it up explicitly. `popstate` only fires on history navigation, never
   // on plain anchor-link clicks — those still get the CSS smooth-scroll.
   window.addEventListener('popstate', anchorScroll);
+  // Smooth in-page scroll that survives mandatory scroll-snap. With
+  // `scroll-snap-type: y mandatory` + `scroll-snap-stop: always` still active,
+  // a programmatic smooth scroll that crosses several chapters gets snagged on
+  // an intermediate snap point and settles there — that's the "land in a random
+  // spot" symptom when jumping from a deep project back to Intro. Drop snap for
+  // the duration of the animated scroll (CSS: html.is-navigating) and restore
+  // it once the scroll settles, so the scroll travels straight to the target;
+  // the target is itself a snap point, so re-enabling snap on arrival is a
+  // no-op. `scrollend` is the precise signal; a timeout backstops browsers
+  // that don't fire it (and the case where the page was already at the target,
+  // so no scroll — hence no scrollend — ever happens).
+  var navReleaseTimer = null;
+  function releaseNavSnap() {
+    clearTimeout(navReleaseTimer);
+    navReleaseTimer = null;
+    window.removeEventListener('scrollend', releaseNavSnap);
+    document.documentElement.classList.remove('is-navigating');
+  }
+  function navScroll(target) {
+    document.documentElement.classList.add('is-navigating');
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    // Adding the same named listener twice is a no-op, so rapid clicks don't
+    // stack handlers; the timer is reset each call so it can't fire mid-scroll.
+    window.addEventListener('scrollend', releaseNavSnap);
+    clearTimeout(navReleaseTimer);
+    navReleaseTimer = setTimeout(releaseNavSnap, 1200);
+  }
+
   // In-page hash links (Work ↓, rail nav, skip link). The native anchor-click
   // scroll lands instantly on this site — `scroll-snap-type: y mandatory`
   // short-circuits the CSS `scroll-behavior: smooth` animation — so hijack
@@ -59,7 +87,11 @@
     if (!target) return;
     e.preventDefault();
     var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    target.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth', block: 'start' });
+    if (reduce) {
+      target.scrollIntoView({ behavior: 'auto', block: 'start' });
+    } else {
+      navScroll(target);
+    }
     // Update URL without firing popstate (which would jump instantly via
     // anchorScroll). pushState records the entry so back/forward still work.
     if (location.hash !== hash) history.pushState(null, '', hash);

--- a/style.css
+++ b/style.css
@@ -92,7 +92,15 @@ a {
   text-underline-offset: 0.18em;
   transition: color 120ms var(--ease);
 }
-a:hover { color: var(--link-hover); }
+/* Hover affordances are gated to real pointers. On iOS Safari (`hover: none`)
+   a link with a :hover style applies that hover state on the first tap and
+   only navigates on a second tap — the "tap once, nothing happens, tap again"
+   bug on body links like "see more of my work". Scoping hover out of the touch
+   path means a tap activates the link immediately. (Same reasoning as the rail
+   below.) */
+@media (hover: hover) {
+  a:hover { color: var(--link-hover); }
+}
 a:focus-visible {
   outline: 2px solid var(--link);
   outline-offset: 3px;
@@ -493,7 +501,9 @@ mark {
   font-size: 0.875rem;
 }
 .meta-links a { text-decoration: none; }
-.meta-links a:hover { text-decoration: underline; }
+@media (hover: hover) {
+  .meta-links a:hover { text-decoration: underline; }
+}
 
 /* ---------- chapter: project variant ---------- */
 
@@ -732,6 +742,16 @@ html.lb-closing .media.is-stack:has(.is-source) .media_item:not(.is-front) {
    Restored on close. (Reduced-motion + print already disable snap globally.) */
 html.lb-open { scroll-snap-type: none; }
 
+/* In-page nav (rail links, skip link, Work ↓) is driven by an explicit smooth
+   `scrollIntoView` in script.js. With `scroll-snap-type: y mandatory` +
+   `scroll-snap-stop: always` still active, a long programmatic scroll that
+   crosses several chapters gets snagged on an intermediate snap point and
+   settles there instead of the target — the "lands in a random spot" symptom
+   when jumping from a deep project section back to Intro. script.js drops snap
+   for the duration of the animated scroll (re-enabling on `scrollend`) so the
+   scroll can travel uninterrupted to the requested section. */
+html.is-navigating { scroll-snap-type: none; }
+
 /* Items are content-sized so vertical media stays narrow and the gap between
    neighbours always reveals real media content as a peek. */
 .lightbox {
@@ -945,8 +965,10 @@ html.lb-open { scroll-snap-type: none; }
   text-underline-offset: 0.22em;
   transition: text-decoration-color 0.18s var(--ease);
 }
-.lightbox_caption a:hover {
-  text-decoration-color: rgba(255, 255, 255, 0.9);
+@media (hover: hover) {
+  .lightbox_caption a:hover {
+    text-decoration-color: rgba(255, 255, 255, 0.9);
+  }
 }
 /* fade the inner text out while the pill's width morphs to the new caption */
 .lightbox_caption.is-swapping .lightbox_caption_text { opacity: 0; }
@@ -1289,11 +1311,13 @@ html.lb-open { scroll-snap-type: none; }
   transition: border-color 160ms var(--ease), background 160ms var(--ease), transform 160ms var(--ease);
 }
 
-.socials_link:hover {
-  border-color: var(--text-light);
-  background: var(--highlight);
-  color: var(--text-default);
-  transform: translateY(-1px);
+@media (hover: hover) {
+  .socials_link:hover {
+    border-color: var(--text-light);
+    background: var(--highlight);
+    color: var(--text-default);
+    transform: translateY(-1px);
+  }
 }
 
 .socials_icon {
@@ -1336,7 +1360,9 @@ html.lb-open { scroll-snap-type: none; }
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
-.chapter_next:hover { color: var(--text-default); }
+@media (hover: hover) {
+  .chapter_next:hover { color: var(--text-default); }
+}
 .chapter_next_arrow {
   font-size: 1rem;
   animation: nudge 1.8s var(--ease) infinite;


### PR DESCRIPTION
Issue 1 (two taps to follow a body link, e.g. "see more of my work"):
the global a:hover and a few other interactive :hover rules weren't gated
behind @media (hover: hover). On iOS Safari (hover: none) the first tap
applies the hover state and only the second tap navigates. Scope all
tappable-link hover affordances to real pointers, matching the rail's
existing approach.

Issue 2 (rail nav lands in a random spot, e.g. Intro from a deep section):
the JS-driven smooth scrollIntoView gets snagged on an intermediate snap
point because scroll-snap-type: y mandatory + scroll-snap-stop: always
stay active during the animation. Drop snap (html.is-navigating) for the
duration of the programmatic scroll and restore it on scrollend so the
scroll travels straight to the target.