### PR TITLE
Fix deck slide arrows dying on first fullscreen entry

### DIFF
--- a/work/index.html
+++ b/work/index.html
@@ -1236,11 +1236,11 @@
             var req = deck.requestFullscreen || deck.webkitRequestFullscreen;
             var pr = req && req.call(deck);
             if (pr && pr.catch) pr.catch(function () {});
-            // Hand keyboard control to the deck so arrow/Page keys drive the
-            // slides in fullscreen. Otherwise focus stays on this button (now
-            // covered by the fullscreen deck) and the shell's nav-key forwarder
-            // drops the keys because the focused element is a <button>.
-            try { frame.focus({ preventScroll: true }); } catch (e2) {}
+            // Focus stays on this button (the deck fills the screen over it),
+            // and moving focus across the iframe boundary in fullscreen is
+            // unreliable. The deck only navigates from key events on its OWN
+            // window, so the shell's nav-key forwarder below routes arrow and
+            // Page keys into the deck while fullscreen; see its `fs` branch.
           }
         } catch (e) { /* fullscreen unavailable, ignore */ }
       });
@@ -1288,20 +1288,55 @@
       if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.altKey) return;
       if (!DECK_NAV_KEYS[e.key]) return;
       var ae = document.activeElement;
+      var frame = active && frames[active];
+      if (!frame || !frame.contentWindow) return;
+      // Is the deck fullscreen? Check the IFRAME'S OWN document, not just this
+      // one. When the deck-stage (inside the iframe) goes fullscreen, the
+      // parent's document.fullscreenElement is unreliable: notably Safari does
+      // not set it on the FIRST entry (only on later ones), which is exactly the
+      // "first time the arrow keys are dead, second time they work" symptom. The
+      // iframe's document, plus the deck's own data-fs flag (which it sets to
+      // drive its rail-collapse), is authoritative, so read fullscreen state
+      // from there.
+      var fs = !!(document.fullscreenElement || document.webkitFullscreenElement);
+      if (!fs) {
+        try {
+          var fdoc = frame.contentDocument;
+          fs = !!(fdoc && (fdoc.fullscreenElement || fdoc.webkitFullscreenElement ||
+                           fdoc.querySelector("deck-stage[data-fs]")));
+        } catch (_) {}
+      }
+      // In fullscreen the shell chrome (home, rail, fullscreen toggle) is hidden
+      // behind the deck, and entering it from the top-bar toggle leaves focus on
+      // that <button>, so real presses fire on this window, never the deck
+      // (which only navigates from key events on its own window). Forward them:
+      // in fullscreen a nav key can only be meant for the slides. Outside
+      // fullscreen, defer to focused buttons / links so their native key
+      // behaviour (Enter / Space activation) is preserved.
       if (ae) {
         var tag = ae.tagName;
-        // Leave focused controls alone: the case dropdown, gate input, links.
+        // Always defer to real text-entry controls, even in fullscreen.
         if (ae === selectEl || ae.isContentEditable ||
-            tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" ||
-            tag === "BUTTON" || tag === "A") return;
+            tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+        // Outside fullscreen, also defer to focused buttons / links and to the
+        // deck iframe itself (it handles its own keys natively). In fullscreen
+        // the chrome is hidden, so forward regardless of which element holds
+        // focus: a nav key can only mean "drive the slides," and a key that
+        // reaches THIS window means focus is in the parent doc, so the deck
+        // isn't also handling it (no double-navigation).
+        if (!fs && (tag === "BUTTON" || tag === "A" || ae === frame)) return;
       }
-      var frame = active && frames[active];
-      if (!frame || !frame.contentWindow || ae === frame) return;
       try {
         frame.contentWindow.dispatchEvent(
           new KeyboardEvent("keydown", { key: e.key, code: e.code })
         );
-        frame.focus({ preventScroll: true });
+        // Outside fullscreen, hand focus to the deck so the next keys reach it
+        // natively. In fullscreen we deliberately DON'T: moving focus across the
+        // iframe boundary there is unreliable, and if it landed focus on the
+        // iframe element, every following press would hit the `ae === frame`
+        // bail above and stop forwarding (only the first key would work).
+        // Leaving focus on the toggle keeps every press flowing through here.
+        if (!fs) frame.focus({ preventScroll: true });
         e.preventDefault();
       } catch (err) {}
     });


### PR DESCRIPTION
## Problem

On the `/work` case-study reader, fullscreening a deck from the top-right toggle left the **arrow keys dead** — slides wouldn't advance until you clicked into the slide. A reliable workaround surfaced it: fullscreen → dismiss → fullscreen again, and keys would start working.

## Root cause

The decks load inside `<iframe>`s, and a deck only navigates from `keydown` events on **its own window**. When you fullscreen from the shell's top-bar toggle, focus ends up on the **iframe element in the parent document**, so real arrow/Page presses fire on the *parent* window, never the deck.

The shell already has a nav-key forwarder built for exactly this "focus drifted to the chrome" case, but two things defeated it in fullscreen:

1. It **bailed whenever a button, link, or the iframe element held focus** — which is precisely the fullscreen state.
2. It detected fullscreen via the parent's `document.fullscreenElement`, which is **unreliable on the first entry** (Safari leaves it null until a later entry — the "first time dead, second time works" symptom).

## Fix

- **Forward nav keys in fullscreen regardless of which chrome element holds focus.** The chrome is hidden behind the deck, so a nav key can only mean "drive the slides," and a key reaching the parent window means the deck isn't also handling it (no double-navigation).
- **Detect fullscreen from the iframe's own document** (and the deck's `data-fs` flag, which it sets to collapse its rail) — authoritative on the first entry.
- **Don't move focus across the iframe boundary in fullscreen** (it's unreliable there); leaving focus put keeps every press flowing through the forwarder instead of only the first.

Non-fullscreen behavior is unchanged: focused buttons/links/the deck iframe still keep their native key handling. Shell-only change (`work/index.html`) so it covers every deck.

## Testing

Verified in the preview by simulating the real browser state (deck fullscreen, focus on the iframe element): `Right/Left/Up/Down` all navigate, including the Up/Down→Left/Right remap, with no double-navigation and no console errors. Non-fullscreen regression checks pass (button-focused keys still don't forward; drift-to-chrome still hands off focus). Confirmed working in @zacharyhalvorson's browser.

> Note: real OS fullscreen can't be driven from the headless preview (it needs a genuine user gesture), so the in-preview checks exercise the code path via simulation; the end-to-end behavior was confirmed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)