### PR TITLE
404: tap the back of your phone to peck

### DIFF
--- a/404.html
+++ b/404.html
@@ -1776,6 +1776,8 @@
         }
       }
       canvas.addEventListener("pointerdown", function (e) {
+        lastPointerTs = performance.now();
+        enableMotionPeck(); // first gesture: iOS motion permission needs one
         var p = { x: e.clientX, y: e.clientY, action: false, directing: false, flapping: false, hold: 0 };
         // a press on the hen, or any extra finger while one already steers, is an
         // action (tap = hop, hold = flap); the first loose finger steers instead
@@ -1792,6 +1794,7 @@
       canvas.addEventListener("pointermove", function (e) {
         var p = pointers[e.pointerId];
         if (!p || !(e.pressure > 0 || e.buttons)) return;
+        lastPointerTs = performance.now();
         if (p.action && !p.directing) {
           // not steering yet: a drag past the slop begins it. if the hold already
           // fired we keep flapping and now steer too (fly + direct); if it hasn't,
@@ -1806,6 +1809,7 @@
       function liftPointer(e) {
         var p = pointers[e.pointerId];
         if (!p) return;
+        lastPointerTs = performance.now();
         clearTimeout(p.hold);
         // a clean tap (an action finger that never steered or flapped) hops
         if (p.action && !p.directing && !p.flapping) hop();
@@ -1815,6 +1819,72 @@
       }
       window.addEventListener("pointerup", liftPointer);
       window.addEventListener("pointercancel", liftPointer);
+
+      // ---- back-tap -> peck (mobile) ----------------------------------------
+      // a knock on the BACK of the phone reads on the accelerometer as one
+      // sharp spike out of stillness, dominant on z (straight through the
+      // body). taps on the glass jolt the sensor too, but those also raise
+      // pointer events, so any spike within a beat of a touch is ignored.
+      // mirrors the shift-key scratch/peck (and eats bugs the same way).
+      var coarseMQ = window.matchMedia("(pointer: coarse)");
+      var motionArmed = false, motionAsked = false;
+      var lastPointerTs = -1e9, lastBackTap = -1e9, calmRun = 0;
+      var gravX = 0, gravY = 0, gravZ = 0, gravSet = false;
+      var TAP_SPIKE = 3.5;  // m/s^2 - the knock itself
+      var TAP_CALM = 1.1;   // m/s^2 - "the phone was just resting" ceiling
+      var TOUCH_GAP = 400, TAP_GAP = 550; // ms: touch quarantine + refractory
+
+      function backTapPeck() {
+        if (reduceMQ.matches || hen.z !== 0 || hen.scratch > 0) return;
+        hen.scratch = SCRATCH_DUR; hen.scratchPuff = 0.06;
+        hen.idle = 0; hen.ate = false; hideHint();
+      }
+
+      function onDeviceMotion(e) {
+        if (!running) return;
+        var ax, ay, az, a = e.acceleration;
+        if (a && a.x != null) { ax = a.x; ay = a.y; az = a.z; }
+        else {
+          // no gyro data: low-pass gravity out of the including-gravity feed
+          var g = e.accelerationIncludingGravity;
+          if (!g || g.x == null) return;
+          if (!gravSet) { gravX = g.x; gravY = g.y; gravZ = g.z; gravSet = true; return; }
+          gravX += (g.x - gravX) * 0.1;
+          gravY += (g.y - gravY) * 0.1;
+          gravZ += (g.z - gravZ) * 0.1;
+          ax = g.x - gravX; ay = g.y - gravY; az = g.z - gravZ;
+        }
+        var mag = Math.hypot(ax, ay, az);
+        var now = performance.now();
+        if (mag > TAP_SPIKE && calmRun >= 3 &&
+            Math.abs(az) >= Math.abs(ax) && Math.abs(az) >= Math.abs(ay) &&
+            now - lastPointerTs > TOUCH_GAP && now - lastBackTap > TAP_GAP) {
+          lastBackTap = now;
+          backTapPeck();
+        }
+        calmRun = mag < TAP_CALM ? calmRun + 1 : 0;
+      }
+
+      function armMotionPeck() {
+        if (motionArmed) return;
+        motionArmed = true;
+        window.addEventListener("devicemotion", onDeviceMotion);
+        if (hintEl && coarseMQ.matches)
+          hintEl.textContent = "drag to walk · tap to hop · hold to flap · tap the back to peck";
+      }
+
+      // iOS gates devicemotion behind a permission that must be requested from
+      // a user gesture; the first touch on the meadow asks once. everywhere
+      // else the listener is armed at load (see GO below).
+      function enableMotionPeck() {
+        if (motionArmed || motionAsked || reduceMQ.matches || !coarseMQ.matches) return;
+        var DM = window.DeviceMotionEvent;
+        if (!DM || typeof DM.requestPermission !== "function") return;
+        motionAsked = true; // one ask per visit - a denial shouldn't nag
+        DM.requestPermission().then(function (state) {
+          if (state === "granted") armMotionPeck();
+        }).catch(function () {});
+      }
 
       // =======================================================================
       //  WIRING: resize, scheme, motion, visibility
@@ -1866,6 +1936,10 @@
       // =======================================================================
       resize();
       spawnCritters();
+      // back-tap peck: sensors that need no permission arm right away; iOS
+      // instead asks on the first touch (requestPermission needs a gesture)
+      if (coarseMQ.matches && !reduceMQ.matches && window.DeviceMotionEvent &&
+          typeof DeviceMotionEvent.requestPermission !== "function") armMotionPeck();
       hen.x = 0; hen.y = 60;
       cam.x = hen.x; cam.y = hen.y; cam.tx = hen.x; cam.ty = hen.y;
       if (reduceMQ.matches) {


### PR DESCRIPTION
## What

Adds a mobile gesture to the 404 meadow: knock on the **back of the phone** and the hen does the same scratch/peck as the desktop Shift key — including gulping a nearby bug via the existing `eatNearbyCritter()` path.

## How it works

- Listens to `devicemotion` and looks for one sharp accelerometer spike (> 3.5 m/s²) arriving out of stillness (≥ 3 consecutive calm samples), dominant on the **z axis** — i.e. straight through the phone's body, the signature of a back tap rather than a shake or a jolt while walking.
- Taps on the glass also jolt the sensor, but those raise pointer events, so any spike within 400 ms of a pointer event is ignored (plus a 550 ms refractory period between pecks). Screen taps stay hops; back taps peck.
- Devices without a gyroscope get a low-pass gravity filter over `accelerationIncludingGravity` as a fallback.

## Permissions

- **iOS**: `DeviceMotionEvent.requestPermission()` must be called from a user gesture, so the first touch on the meadow asks once. A denial isn't nagged again for the visit.
- **Android / others**: no permission API, so the listener arms at load.

## Guardrails

- Only on coarse-pointer (touch) devices; no-op where `DeviceMotionEvent` doesn't exist.
- Respects `prefers-reduced-motion` (never asks, never arms, and the handler bails when the sim isn't running).
- Same grounding rules as Shift: no peck mid-hop or mid-scratch.
- The coarse-pointer hint now reads `drag to walk · tap to hop · hold to flap · tap the back to peck`.

## Testing

- `node --check` on the extracted inline script.
- Headless Chromium (Pixel 7 emulation): hint text confirms the listener arms at load; synthetic `devicemotion` events (calm samples then a z spike) visibly pitch the hen into the peck; a spike immediately after a screen tap does not; no page errors.
- **Needs a real-device pass** (hence draft): tune `TAP_SPIKE` / `TAP_CALM` feel on an actual phone, and confirm the iOS permission prompt on first touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrDwcdBUwR8AJYz4jez9Yk

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrDwcdBUwR8AJYz4jez9Yk)_