### PR TITLE
Fix double-tap needed on body links on iOS (gate entrance reveals to hover devices)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Deployed via **GitHub Pages** from the `master` branch. Push to `master` and the
 - **Mobile-first** responsive design
 - **CSS custom properties** in `:root`, with full **dark mode** parity via `@media (prefers-color-scheme: dark)`
 - **Scroll-snap**: `html { scroll-snap-type: y mandatory }` + `.chapter { scroll-snap-align: start; min-height: 100svh }`
-- **Entrance reveals**: CSS scroll-driven animations (`animation-timeline: view()`) inside `@supports` — graceful degradation. Desktop-pointer only (`@media (hover: hover)`): on touch, the reveal's scroll-coupled style changes trip iOS Safari's content-change tap heuristic and links inside revealed blocks need two taps
+- **Entrance reveals**: CSS scroll-driven animations (`animation-timeline: view()`) inside `@supports` — graceful degradation. Gated to `@media (hover: hover) and (not (any-pointer: coarse))` — i.e. no touch input anywhere: the reveal's scroll-coupled style changes trip iOS Safari's content-change tap heuristic and links inside revealed blocks need two taps (hover alone isn't enough — an iPad with a paired trackpad reports `hover: hover` while fingers still tap)
 - **Scroll progress bar**: `animation-timeline: scroll(root)` on a fixed 2px top bar
 - **Reduced motion**: `@media (prefers-reduced-motion: reduce)` disables snap, smooth scroll, and all animations
 - **Print stylesheet**: flattens scroll-snap and prints as a clean resume

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Deployed via **GitHub Pages** from the `master` branch. Push to `master` and the
 - **Mobile-first** responsive design
 - **CSS custom properties** in `:root`, with full **dark mode** parity via `@media (prefers-color-scheme: dark)`
 - **Scroll-snap**: `html { scroll-snap-type: y mandatory }` + `.chapter { scroll-snap-align: start; min-height: 100svh }`
-- **Entrance reveals**: CSS scroll-driven animations (`animation-timeline: view()`) inside `@supports` — graceful degradation
+- **Entrance reveals**: CSS scroll-driven animations (`animation-timeline: view()`) inside `@supports` — graceful degradation. Desktop-pointer only (`@media (hover: hover)`): on touch, the reveal's scroll-coupled style changes trip iOS Safari's content-change tap heuristic and links inside revealed blocks need two taps
 - **Scroll progress bar**: `animation-timeline: scroll(root)` on a fixed 2px top bar
 - **Reduced motion**: `@media (prefers-reduced-motion: reduce)` disables snap, smooth scroll, and all animations
 - **Print stylesheet**: flattens scroll-snap and prints as a clean resume

--- a/style.css
+++ b/style.css
@@ -106,6 +106,11 @@ a:focus-visible {
   outline-offset: 3px;
   border-radius: 2px;
 }
+/* Activate on the first tap. `manipulation` opts links and buttons out of
+   double-tap-to-zoom, so mobile Safari can dispatch the click immediately
+   instead of holding it while it disambiguates gestures. Panning and
+   pinch-zoom are unaffected. */
+a, button { touch-action: manipulation; }
 
 ul, ol, dl, dd { margin: 0; padding: 0; }
 .list-reset { list-style: none; }
@@ -1464,16 +1469,30 @@ html.is-navigating { scroll-snap-type: none; }
      Both must always be visible, so they get no reveal rather than an
      intermittent disappearing act. The taller body blocks below keep the fade:
      their long entry range gives the compositor enough sample frames that the
-     freeze doesn't bite. */
-  .chapter_body > *:nth-child(n+2) {
-    animation: reveal linear both;
-    animation-timeline: view();
-  }
+     freeze doesn't bite.
 
-  .chapter_body > *:nth-child(2) { animation-range: entry 6%  entry 36%; }
-  .chapter_body > *:nth-child(3) { animation-range: entry 10% entry 42%; }
-  .chapter_body > *:nth-child(4) { animation-range: entry 14% entry 48%; }
-  .chapter_body > *:nth-child(5) { animation-range: entry 18% entry 54%; }
+     The reveal is also gated to hover-capable (non-touch) devices. On iOS
+     Safari a tap dispatches synthetic mouse events first, and WebKit's
+     content-change observer withholds the click when the tapped content's
+     styles change in response — the heuristic that makes hover-menus need
+     tap-then-tap. A mandatory-snap page is rarely perfectly still (snap
+     settling and toolbar collapse nudge the scroll offset), and any nudge
+     re-samples these view() animations, mutating the opacity/transform of
+     the very block being tapped. Net effect: body links inside revealed
+     blocks (the Dooly Crunchbase link, "see more of my work") needed two
+     taps. No reveal on touch → no style change under the tap → the first
+     tap navigates. */
+  @media (hover: hover) {
+    .chapter_body > *:nth-child(n+2) {
+      animation: reveal linear both;
+      animation-timeline: view();
+    }
+
+    .chapter_body > *:nth-child(2) { animation-range: entry 6%  entry 36%; }
+    .chapter_body > *:nth-child(3) { animation-range: entry 10% entry 42%; }
+    .chapter_body > *:nth-child(4) { animation-range: entry 14% entry 48%; }
+    .chapter_body > *:nth-child(5) { animation-range: entry 18% entry 54%; }
+  }
 
   @keyframes reveal {
     from {

--- a/style.css
+++ b/style.css
@@ -96,8 +96,9 @@ a {
    a link with a :hover style applies that hover state on the first tap and
    only navigates on a second tap — the "tap once, nothing happens, tap again"
    bug on body links like "see more of my work". Scoping hover out of the touch
-   path means a tap activates the link immediately. (Same reasoning as the rail
-   below.) */
+   path removes this cause of the eaten first tap — the scroll-driven entrance
+   reveals are gated for the same symptom's other cause (see the entrance-reveals
+   section near the bottom). (Same reasoning as the rail below.) */
 @media (hover: hover) {
   a:hover { color: var(--link-hover); }
 }
@@ -1481,8 +1482,14 @@ html.is-navigating { scroll-snap-type: none; }
      the very block being tapped. Net effect: body links inside revealed
      blocks (the Dooly Crunchbase link, "see more of my work") needed two
      taps. No reveal on touch → no style change under the tap → the first
-     tap navigates. */
-  @media (hover: hover) {
+     tap navigates.
+
+     `not (any-pointer: coarse)` keeps the gate honest on hybrid devices: an
+     iPad with a paired trackpad flips to `hover: hover` while fingers still
+     tap the screen (and still run the same WebKit tap heuristic), so hover
+     capability alone isn't proof there's no touch input. Any device with a
+     coarse pointer anywhere keeps the static, always-tappable content. */
+  @media (hover: hover) and (not (any-pointer: coarse)) {
     .chapter_body > *:nth-child(n+2) {
       animation: reveal linear both;
       animation-timeline: view();
@@ -1519,6 +1526,13 @@ html.is-navigating { scroll-snap-type: none; }
     animation-iteration-count: 1 !important;
     transition-duration: 0.001ms !important;
   }
+  /* The duration clamp above is a spec-guaranteed no-op for scroll-driven
+     animations: progress-based timelines (view()/scroll()) normalize time
+     values onto the scroll range, so a 0.001ms reveal still fades and
+     translates across its full entry range. Remove those animations outright.
+     The progress bar's base style is scaleX(0), so it simply rests empty. */
+  .progress,
+  .chapter_body > * { animation: none !important; }
   /* Keep the full name visible, no fade, no collapse, no spring, when motion is reduced. */
   .display_dim { opacity: 1; font-size: 1em; }
   .display_shift { display: inline; }


### PR DESCRIPTION
## Problem

On mobile, links in the chapter body text — e.g. the Dooly Crunchbase link — do nothing on the first tap; a second tap fires them. This persisted after #63's fix (`320710f`) gated all `:hover` styles behind `@media (hover: hover)`, so hover emulation wasn't (or wasn't the only) cause.

## Diagnosis

Every affected link sits inside a block animated by the scroll-driven entrance reveal (`.chapter_body > *:nth-child(n+2)` with `animation-timeline: view()`, animating `opacity` and `translateY`). On iOS Safari, a tap dispatches synthetic mouse events first, and WebKit's content-change observer **withholds the click when the tapped content's styles change in response** — the same heuristic that makes hover-menus need tap-then-tap.

A `scroll-snap-type: y mandatory` page is rarely perfectly still: snap settling and the dynamic toolbar nudge the scroll offset by fractions of a pixel. Any nudge re-samples the `view()` animation, mutating the opacity/transform of the very paragraph being tapped, right in the observation window — so Safari classifies the tap as "hover revealed content" and swallows the click. The second tap lands on a fully settled page and navigates. (The stylesheet already documents that snap landings freeze these `view()` animations mid-flight — the heading and meta column were excluded from the reveal for that reason.)

## Fix

- Gate the entrance reveals to `@media (hover: hover) and (not (any-pointer: coarse))` inside the existing `@supports (animation-timeline: view())` block. Any device with touch input anywhere gets static, always-visible body content; pure-pointer desktops keep the reveals unchanged. The `any-pointer` half matters because an iPad with a paired trackpad reports `hover: hover` while fingers still tap the screen — hover capability alone would re-admit the bug there.
- Add `touch-action: manipulation` to `a, button` so mobile taps aren't held for double-tap-to-zoom disambiguation (pan and pinch-zoom unaffected; the lightbox's stricter `touch-action: none` stamp still wins on its own controls).
- Reduced-motion fix surfaced by code review: the universal `animation-duration: 0.001ms` clamp is a spec-guaranteed no-op for scroll-driven animations (progress-based timelines normalize time values onto the scroll range), so the reveal and the progress bar still animated for `prefers-reduced-motion` users. They're now removed explicitly in the reduced-motion block.
- Updated the CLAUDE.md entrance-reveals note and cross-referenced the older `a:hover` gating comment, which overclaimed that it alone fixed first-tap activation.

## Verification

Playwright (Chromium) against a local server, four profiles:
- Touch mobile (390×844): reveal animation absent, `.chapter_text` at `opacity: 1`, link has `touch-action: manipulation`, one synthetic tap fires exactly one click.
- Desktop: reveal present with `animation-timeline: view()`; progress bar animates.
- Desktop + touchscreen: reveal absent (coarse pointer present).
- Desktop + `prefers-reduced-motion: reduce`: reveal **and** progress-bar animations are `none` (both previously survived the duration clamp).

Chromium can't reproduce the iOS tap heuristic itself, so the real confirmation is a tap on an iPhone: scroll to Dooly and tap the Crunchbase link once — it should open on the first tap.

## Code review

Ran the high-effort review harness over the diff (8 finder angles, adversarial verification). Three findings survived and are fixed in the follow-up commit: the hybrid-device gate hole (PLAUSIBLE), the reduced-motion no-op (CONFIRMED), and the overclaiming comment (PLAUSIBLE). Refuted candidates included: dead `button` selector (deliberate forward-proofing, lightbox override is load-bearing), double-tap-zoom removal (standard practice, pinch-zoom intact), progress-bar tripping the same tap heuristic (it never transitions visibility and isn't attributable to the tap window), and the `chapter_next` arrow's infinite nudge (steady-state animations don't trip WebKit's observer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzGre5hWfrA8pfKXcvMYV3