### PR TITLE
Update header and footer copy for DoorDash move

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       "url": "https://zacharyhalvorson.com/",
       "image": "https://zacharyhalvorson.com/embed-image.jpg",
       "jobTitle": "Staff Product Designer",
-      "worksFor": { "@type": "Organization", "name": "Meta Reality Labs" },
+      "worksFor": { "@type": "Organization", "name": "DoorDash" },
       "alumniOf": [
         { "@type": "CollegeOrUniversity", "name": "Capilano University" },
         { "@type": "CollegeOrUniversity", "name": "University of Alberta" }
@@ -132,6 +132,7 @@
           <header class="chapter_meta">
             <span class="chapter_index">02 <span aria-hidden="true">/</span> 06</span>
             <p class="chapter_role">Staff Product Designer · Meta Reality Labs</p>
+            <p class="chapter_when"><time datetime="2020">2020</time> to <time datetime="2026">2026</time></p>
             <p class="chapter_where">Seattle, WA</p>
           </header>
           <div class="chapter_body">
@@ -171,6 +172,7 @@
           <header class="chapter_meta">
             <span class="chapter_index">03 <span aria-hidden="true">/</span> 06</span>
             <p class="chapter_role">Staff Product Designer · Meta Reality Labs</p>
+            <p class="chapter_when"><time datetime="2020">2020</time> to <time datetime="2026">2026</time></p>
             <p class="chapter_where">Seattle, WA</p>
           </header>
           <div class="chapter_body">

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
         <div class="chapter_inner">
           <header class="chapter_meta">
             <span class="chapter_index">01 <span aria-hidden="true">/</span> 06</span>
-            <p class="chapter_kicker">Product Designer · Seattle (for now?)</p>
+            <p class="chapter_kicker">Product Designer · Seattle</p>
           </header>
           <div class="chapter_body">
             <h1 id="intro-heading" class="display">Hi there,<br class="display_break"> I'm <span class="display_em">Zach<span class="display_dim">ary</span>&nbsp;<span class="display_shift">Halvorson</span></span></h1>
@@ -309,7 +309,7 @@
           </header>
           <div class="chapter_body">
             <h2 id="hello-heading" class="display">Thanks for <span class="display_em">scrolling.</span></h2>
-            <p class="lede">After 5+ years at Meta, wrapping up while on <mark>Agent Harnesses and Generative UI</mark>, I'm currently looking for my next role. If you've got questions, or if you want to <a href="/work/">see more of my work</a>, <a href="mailto:zacharyhalvorson@me.com">feel free to reach out</a>.</p>
+            <p class="lede">After 5+ years at Meta working on <mark>AI and Wearables</mark>, I'm starting a new chapter at DoorDash. If you've got questions, or if you want to <a href="/work/">see more of my work</a>, <a href="mailto:zacharyhalvorson@me.com">feel free to reach out</a>.</p>
             <p class="lede">On the side I'm building <a href="https://github.com/zacharyhalvorson/trip-cams" target="_blank" rel="noopener noreferrer">Trip Cams</a>, a road-trip companion that shows live traffic cameras along your route, and <a href="https://github.com/zacharyhalvorson/Remote-Terminal" target="_blank" rel="noopener noreferrer">Remote Terminal</a>, a zero-setup way to use your Mac from anywhere.</p>
 
             <ul class="socials list-reset">


### PR DESCRIPTION
## Summary

Copy updates in `index.html` to reflect the move to DoorDash — text and metadata only, no style or script changes.

- **Footer (colophon lede):** "After 5+ years at Meta working on **AI and Wearables**, I'm starting a new chapter at DoorDash." replaces the job-searching language; the `<mark>` highlight now wraps "AI and Wearables".
- **Header (intro kicker):** "Product Designer · Seattle (for now?)" → "Product Designer · Seattle"
- **Structured data:** JSON-LD `worksFor` updated from Meta Reality Labs to DoorDash so search engines pick up the current employer.
- **Meta project chapters:** added "2020 to 2026" date ranges to Meta Ray-Ban Display and Ray-Ban Meta, matching the dated Clio and Dooly chapters so the Meta roles read as past positions.

Verified on the Vercel preview: all copy renders correctly and the page loads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4Kn7x5JZUg3FCn55Rc25Z