### PR TITLE
Remove "Staff" from website title and meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     <script src="./script.js?v=20260614a" defer></script>
     <link rel="canonical" href="https://zacharyhalvorson.com/">
 
-    <title>Zachary Halvorson — Staff Product Designer</title>
-    <meta name="description" content="Zachary Halvorson is a Staff Product Designer focused on AI Design and Building. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
+    <title>Zachary Halvorson — Product Designer</title>
+    <meta name="description" content="Zachary Halvorson is a Product Designer focused on AI Design and Building. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
     <meta name="author" content="Zachary Halvorson">
 
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
@@ -18,8 +18,8 @@
     <meta property="og:site_name" content="Zachary Halvorson">
     <meta property="og:locale" content="en_US">
     <meta property="og:url" content="https://zacharyhalvorson.com/">
-    <meta property="og:title" content="Zachary Halvorson — Staff Product Designer">
-    <meta property="og:description" content="Staff Product Designer focused on AI Design and Building. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
+    <meta property="og:title" content="Zachary Halvorson — Product Designer">
+    <meta property="og:description" content="Product Designer focused on AI Design and Building. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
     <meta property="og:image" content="https://zacharyhalvorson.com/embed-image.jpg">
     <meta property="og:image:type" content="image/jpeg">
     <meta property="og:image:width" content="1200">
@@ -27,8 +27,8 @@
     <meta property="og:image:alt" content="Portrait of Zachary Halvorson.">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:creator" content="@zachhalvorson">
-    <meta name="twitter:title" content="Zachary Halvorson — Staff Product Designer">
-    <meta name="twitter:description" content="Staff Product Designer focused on AI Design and Building. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
+    <meta name="twitter:title" content="Zachary Halvorson — Product Designer">
+    <meta name="twitter:description" content="Product Designer focused on AI Design and Building. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
     <meta name="twitter:image" content="https://zacharyhalvorson.com/embed-image.jpg">
     <meta name="twitter:image:alt" content="Portrait of Zachary Halvorson.">
 
@@ -53,7 +53,7 @@
       "name": "Zachary Halvorson",
       "url": "https://zacharyhalvorson.com/",
       "image": "https://zacharyhalvorson.com/embed-image.jpg",
-      "jobTitle": "Staff Product Designer",
+      "jobTitle": "Product Designer",
       "worksFor": { "@type": "Organization", "name": "DoorDash" },
       "alumniOf": [
         { "@type": "CollegeOrUniversity", "name": "Capilano University" },

--- a/script.js
+++ b/script.js
@@ -124,7 +124,7 @@
     var narrow = window.matchMedia && window.matchMedia('(max-width: 599px)').matches;
     var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     if (narrow || reduce) return;
-    setTimeout(function () { document.title = 'Zach Halvorson — Staff Product Designer'; }, 5100);
+    setTimeout(function () { document.title = 'Zach Halvorson — Product Designer'; }, 5100);
   })();
 
   // ---------- iOS-style squircle corners ----------


### PR DESCRIPTION
Updates the site's self-description from "Staff Product Designer" to "Product Designer" so the title reads less limiting.

## Changes

- `index.html`
  - `<title>` → "Zachary Halvorson — Product Designer"
  - `meta description`, `og:title`, `og:description`, `twitter:title`, `twitter:description` updated to match
  - JSON-LD Person schema `jobTitle` → "Product Designer"
- `script.js` — the delayed tab-title collapse now sets "Zach Halvorson — Product Designer"

## Intentionally unchanged

- `.chapter_role` lines on the Meta chapters ("Staff Product Designer · Meta Reality Labs") and the eyebrows on the `work/` subpages, since those state the actual title held in that role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mHsfz4mQgyjF71MWRouDo

---
_Generated by [Claude Code](https://claude.ai/code/session_016mHsfz4mQgyjF71MWRouDo)_