### PR TITLE
Shorten mailto link text to just "reach out"

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,7 +311,7 @@
           </header>
           <div class="chapter_body">
             <h2 id="hello-heading" class="display">Thanks for <span class="display_em">scrolling.</span></h2>
-            <p class="lede">After 5+ years at Meta working on <mark>AI and Wearables</mark>, I'm starting a new chapter at DoorDash. If you've got questions, or if you want to <a href="/work/">see more of my work</a>, <a href="mailto:zacharyhalvorson@me.com">feel free to reach out</a>.</p>
+            <p class="lede">After 5+ years at Meta working on <mark>AI and Wearables</mark>, I'm starting a new chapter at DoorDash. If you've got questions, or if you want to <a href="/work/">see more of my work</a>, feel free to <a href="mailto:zacharyhalvorson@me.com">reach out</a>.</p>
             <p class="lede">On the side I'm building <a href="https://github.com/zacharyhalvorson/trip-cams" target="_blank" rel="noopener noreferrer">Trip Cams</a>, a road-trip companion that shows live traffic cameras along your route, and <a href="https://github.com/zacharyhalvorson/Remote-Terminal" target="_blank" rel="noopener noreferrer">Remote Terminal</a>, a zero-setup way to use your Mac from anywhere.</p>
 
             <ul class="socials list-reset">


### PR DESCRIPTION
In the colophon, the mailto link previously wrapped the full phrase "feel free to reach out", which read as too long. Now only "reach out" is linked; "feel free to" stays as plain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEnYvTVEU3BjCJRLeNihra

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEnYvTVEU3BjCJRLeNihra)_