### PR TITLE
Fix persistent double-tap on colophon links

### DIFF
--- a/style.css
+++ b/style.css
@@ -91,6 +91,13 @@ a {
   text-decoration-thickness: 1px;
   text-underline-offset: 0.18em;
   transition: color 120ms var(--ease);
+  /* The page stays pinch-zoomable (no maximum-scale — accessibility), which
+     leaves iOS Safari's double-tap-to-zoom heuristic arbitrating every tap on
+     zoomable text. A tap on a small inline link inside a paragraph can be
+     held back as a potential first half of a text zoom instead of dispatched
+     as a click. `manipulation` opts the link itself out of that arbitration
+     (pan + pinch stay available) so a single tap always clicks. */
+  touch-action: manipulation;
 }
 /* Hover affordances are gated to real pointers. On iOS Safari (`hover: none`)
    a link with a :hover style applies that hover state on the first tap and
@@ -1475,14 +1482,36 @@ html.is-navigating { scroll-snap-type: none; }
   .chapter_body > *:nth-child(4) { animation-range: entry 14% entry 48%; }
   .chapter_body > *:nth-child(5) { animation-range: entry 18% entry 54%; }
 
+  /* Touch devices get the fade WITHOUT the 14px rise. The revealed blocks
+     contain the page's inline links (colophon: "see more of my work",
+     "reach out", Trip Cams, Remote Terminal; plus each project lede's link),
+     and on iOS Safari the view() timeline is sampled off the main thread —
+     the same snap-landing mis-sampling documented above that freezes
+     keyframes also leaves hit testing holding the block's *shifted* transform
+     after the landing. A tap then targets geometry the text no longer
+     occupies: first tap misses the link, second tap (after a re-sample)
+     lands — the "double tap to follow a colophon link" bug. Gating :hover
+     (June fix) didn't cure it because hover was never the mechanism. Opacity
+     plays no part in hit testing, so the fade itself is safe everywhere; the
+     rise is reserved for fine-pointer devices, where there are no taps to
+     eat. */
   @keyframes reveal {
-    from {
-      opacity: 0;
-      transform: translateY(14px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .chapter_body > *:nth-child(n+2) { animation-name: reveal-rise; }
+
+    @keyframes reveal-rise {
+      from {
+        opacity: 0;
+        transform: translateY(14px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

Text hyperlinks in the colophon ("see more of my work", "reach out", Trip Cams, Remote Terminal) still need two taps on mobile — the first tap does nothing, the second navigates. The June fix (#320710f gating `:hover` behind `@media (hover: hover)`) didn't cure it, because a color-only hover style never suppressed iOS clicks in the first place; hover was never the mechanism.

## Diagnosis

Two remaining mechanisms can eat the first tap on these links, and both are addressed here (CSS-only, no markup or JS changes):

1. **Transformed scroll-driven reveal under the links.** The entrance reveal animates the link-bearing lede blocks with `translateY(14px)` on an `animation-timeline: view()` timeline. iOS Safari samples `view()` timelines off the main thread, and the same scroll-snap-landing mis-sampling this stylesheet already documents (the reason `.display` and `.chapter_meta` are excluded from the reveal) can leave hit testing holding the block's *shifted* transform after a snap landing. The first tap then targets geometry the text no longer occupies; the second tap, after a re-sample, lands. The colophon is the terminal snap landing, which is why it bites hardest there.
2. **Double-tap-to-zoom arbitration.** The page is intentionally pinch-zoomable (no `maximum-scale`, good for accessibility), so taps on zoomable text remain candidates for Safari's double-tap-to-zoom heuristic, which can hold back a tap on a small inline link.

## Fix

- Touch devices (`hover: none` / coarse pointer) now get a **fade-only reveal** — opacity plays no part in hit testing, so frozen or lagging samples can never displace tap targets. Devices with `(hover: hover) and (pointer: fine)` keep the original fade + 14px rise (`reveal-rise`).
- Links get `touch-action: manipulation`, opting them out of double-tap-zoom arbitration while keeping pan and pinch-zoom intact.

## Testing

- Playwright (Chromium): desktop viewport resolves the lede's animation to `reveal-rise`; mobile/touch emulation resolves to fade-only `reveal` and `touch-action: manipulation` on the links; after scrolling to `#hello`, the lede settles at `opacity: 1`, `transform: none`.
- Mobile colophon screenshot verified — layout, dark-mode variables, and reveal exclusions untouched.
- CSS brace-balance checked; changes are additive within the existing `@supports (animation-timeline: view())` block, so browsers without scroll-driven animation support are unaffected, and the reduced-motion block still disables everything.

Worth a real-device check on iPhone Safari: scroll to the colophon and single-tap each text link — each should navigate on the first tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A78dcz3f6PjTpZWzWcHp9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01A78dcz3f6PjTpZWzWcHp9f)_