### PR TITLE
Update contact email to hello@zacharyhalvorson.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     <link rel="me" href="https://www.linkedin.com/in/zacharyhalvorson/">
     <link rel="me" href="https://github.com/zacharyhalvorson">
     <link rel="me" href="https://x.com/zachhalvorson">
-    <link rel="me" href="mailto:zacharyhalvorson@me.com">
+    <link rel="me" href="mailto:hello@zacharyhalvorson.com">
 
     <link rel="apple-touch-icon-precomposed" href="apple-touch-icon.png">
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
@@ -311,7 +311,7 @@
           </header>
           <div class="chapter_body">
             <h2 id="hello-heading" class="display">Thanks for <span class="display_em">scrolling.</span></h2>
-            <p class="lede">After 5+ years at Meta working on <mark>AI and Wearables</mark>, I'm starting a new chapter at DoorDash. If you've got questions, or if you want to <a href="/work/">see more of my work</a>, feel free to <a href="mailto:zacharyhalvorson@me.com">reach out</a>.</p>
+            <p class="lede">After 5+ years at Meta working on <mark>AI and Wearables</mark>, I'm starting a new chapter at DoorDash. If you've got questions, or if you want to <a href="/work/">see more of my work</a>, feel free to <a href="mailto:hello@zacharyhalvorson.com">reach out</a>.</p>
             <p class="lede">On the side I'm building <a href="https://github.com/zacharyhalvorson/trip-cams" target="_blank" rel="noopener noreferrer">Trip Cams</a>, a road-trip companion that shows live traffic cameras along your route, and <a href="https://github.com/zacharyhalvorson/Remote-Terminal" target="_blank" rel="noopener noreferrer">Remote Terminal</a>, a zero-setup way to use your Mac from anywhere.</p>
 
             <ul class="socials list-reset">
@@ -324,7 +324,7 @@
                 <img class="socials_icon" src="media/socials/linkedin.svg" alt="" aria-hidden="true" decoding="async">
                 <span>LinkedIn</span>
               </a></li>
-              <li><a class="socials_link" href="mailto:zacharyhalvorson@me.com">
+              <li><a class="socials_link" href="mailto:hello@zacharyhalvorson.com">
                 <span class="socials_icon socials_icon-glyph" aria-hidden="true">@</span>
                 <span>Email</span>
               </a></li>

--- a/resume/index.html
+++ b/resume/index.html
@@ -225,7 +225,7 @@
 
     <address class="contact">
       <span>5300 9 Ave NW, Seattle WA</span>
-      <a href="mailto:zacharyhalvorson@me.com">zacharyhalvorson@me.com</a>
+      <a href="mailto:hello@zacharyhalvorson.com">hello@zacharyhalvorson.com</a>
       <a href="https://zacharyhalvorson.com/">zacharyhalvorson.com</a>
     </address>
 

--- a/work/index.html
+++ b/work/index.html
@@ -490,7 +490,7 @@
       </form>
       <p class="gate_help">
         Need access, or having trouble with your passphrase? Email
-        <a href="mailto:zacharyhalvorson@me.com?subject=Case%20study%20access">zacharyhalvorson@me.com</a>
+        <a href="mailto:hello@zacharyhalvorson.com?subject=Case%20study%20access">hello@zacharyhalvorson.com</a>
         and I&rsquo;ll get you in.
       </p>
       <p class="gate_back"><a href="../">&larr; Back to zacharyhalvorson.com</a></p>

--- a/work/rayban-meta/index.html
+++ b/work/rayban-meta/index.html
@@ -1219,7 +1219,7 @@
     </div>
     <div class="footer anim-4" style="font-size:27px;" data-om-id="4ba0b514:323">
       <span data-om-id="4ba0b514:324">Zachary Halvorson · Design Lead</span>
-      <span data-om-id="4ba0b514:325">zacharyhalvorson.com · zacharyhalvorson@me.com</span>
+      <span data-om-id="4ba0b514:325">zacharyhalvorson.com · hello@zacharyhalvorson.com</span>
     </div>
   </section>
 


### PR DESCRIPTION
Replaces `zacharyhalvorson@me.com` with the new custom-domain address `hello@zacharyhalvorson.com` (set up through iCloud) everywhere it appears:

- `index.html` — `rel="me"` link, the "reach out" mailto in the colophon, and the socials email link
- `resume/index.html` — contact line (href + visible text)
- `work/index.html` — case-study access request mailto (subject param preserved)
- `work/rayban-meta/index.html` — deck footer contact line

No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDuKpXpFZnEWcCwnCgwcF3

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDuKpXpFZnEWcCwnCgwcF3)_