### PR TITLE
Update resume: wrapped up at Meta in July 2026, now Staff Product Designer at DoorDash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Personal site for Zachary Halvorson — a product designer based in Seattle, currently at Meta Reality Labs. Deployed at [www.zacharyhalvorson.com](https://www.zacharyhalvorson.com).
+Personal site for Zachary Halvorson — a product designer based in Seattle, currently a Staff Product Designer at DoorDash (previously Meta Reality Labs). Deployed at [www.zacharyhalvorson.com](https://www.zacharyhalvorson.com).
 
 The site is a single-page, scroll-snapped portfolio: an intro section followed by one full-viewport section per project (Meta Ray-Ban Display → Ray-Ban Meta → Clio Scheduler → Dooly), each with a representative image, then a closing colophon with education and contact.
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="canonical" href="https://zacharyhalvorson.com/">
 
     <title>Zachary Halvorson — Product Designer</title>
-    <meta name="description" content="Zachary Halvorson is a Product Designer focused on AI Design and Building. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
+    <meta name="description" content="Zachary Halvorson is a Staff Product Designer at DoorDash, building merchant experiences that help businesses expand their market. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
     <meta name="author" content="Zachary Halvorson">
 
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
@@ -19,7 +19,7 @@
     <meta property="og:locale" content="en_US">
     <meta property="og:url" content="https://zacharyhalvorson.com/">
     <meta property="og:title" content="Zachary Halvorson — Product Designer">
-    <meta property="og:description" content="Product Designer focused on AI Design and Building. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
+    <meta property="og:description" content="Staff Product Designer at DoorDash, building merchant experiences. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
     <meta property="og:image" content="https://zacharyhalvorson.com/embed-image.jpg">
     <meta property="og:image:type" content="image/jpeg">
     <meta property="og:image:width" content="1200">
@@ -28,7 +28,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:creator" content="@zachhalvorson">
     <meta name="twitter:title" content="Zachary Halvorson — Product Designer">
-    <meta name="twitter:description" content="Product Designer focused on AI Design and Building. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
+    <meta name="twitter:description" content="Staff Product Designer at DoorDash, building merchant experiences. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
     <meta name="twitter:image" content="https://zacharyhalvorson.com/embed-image.jpg">
     <meta name="twitter:image:alt" content="Portrait of Zachary Halvorson.">
 
@@ -53,7 +53,7 @@
       "name": "Zachary Halvorson",
       "url": "https://zacharyhalvorson.com/",
       "image": "https://zacharyhalvorson.com/embed-image.jpg",
-      "jobTitle": "Product Designer",
+      "jobTitle": "Staff Product Designer",
       "worksFor": { "@type": "Organization", "name": "DoorDash" },
       "alumniOf": [
         { "@type": "CollegeOrUniversity", "name": "Capilano University" },
@@ -98,7 +98,7 @@
         <div class="chapter_inner">
           <header class="chapter_meta">
             <span class="chapter_index">01 <span aria-hidden="true">/</span> 06</span>
-            <p class="chapter_kicker">Product Designer · Seattle</p>
+            <p class="chapter_kicker">Staff Product Designer · DoorDash · Seattle</p>
           </header>
           <div class="chapter_body">
             <h1 id="intro-heading" class="display">Hi there,<br class="display_break"> I'm <span class="display_em">Zach<span class="display_dim">ary</span>&nbsp;<span class="display_shift">Halvorson</span></span></h1>
@@ -132,7 +132,7 @@
           <header class="chapter_meta">
             <span class="chapter_index">02 <span aria-hidden="true">/</span> 06</span>
             <p class="chapter_role">Staff Product Designer · Meta Reality Labs</p>
-            <p class="chapter_when"><time datetime="2020">2020</time> to <time datetime="2026">2026</time></p>
+            <p class="chapter_when"><time datetime="2020">2020</time> to <time datetime="2026-07">2026</time></p>
             <p class="chapter_where">Seattle, WA</p>
           </header>
           <div class="chapter_body">
@@ -172,7 +172,7 @@
           <header class="chapter_meta">
             <span class="chapter_index">03 <span aria-hidden="true">/</span> 06</span>
             <p class="chapter_role">Staff Product Designer · Meta Reality Labs</p>
-            <p class="chapter_when"><time datetime="2020">2020</time> to <time datetime="2026">2026</time></p>
+            <p class="chapter_when"><time datetime="2020">2020</time> to <time datetime="2026-07">2026</time></p>
             <p class="chapter_where">Seattle, WA</p>
           </header>
           <div class="chapter_body">
@@ -311,7 +311,7 @@
           </header>
           <div class="chapter_body">
             <h2 id="hello-heading" class="display">Thanks for <span class="display_em">scrolling.</span></h2>
-            <p class="lede">After 5+ years at Meta working on <mark>AI and Wearables</mark>, I'm starting a new chapter at DoorDash. If you've got questions, or if you want to <a href="/work/">see more of my work</a>, feel free to <a href="mailto:hello@zacharyhalvorson.com">reach out</a>.</p>
+            <p class="lede">After 5+ years at Meta working on <mark>AI and Wearables</mark>, I wrapped up in July 2026 and started a new chapter at DoorDash, designing merchant experiences that help businesses expand their market. If you've got questions, or if you want to <a href="/work/">see more of my work</a>, feel free to <a href="mailto:hello@zacharyhalvorson.com">reach out</a>.</p>
             <p class="lede">On the side I'm building <a href="https://github.com/zacharyhalvorson/trip-cams" target="_blank" rel="noopener noreferrer">Trip Cams</a>, a road-trip companion that shows live traffic cameras along your route, and <a href="https://github.com/zacharyhalvorson/Remote-Terminal" target="_blank" rel="noopener noreferrer">Remote Terminal</a>, a zero-setup way to use your Mac from anywhere.</p>
 
             <ul class="socials list-reset">


### PR DESCRIPTION
Updates the site to reflect the move from Meta to DoorDash.

## Changes

- **Intro kicker**: now reads "Staff Product Designer · DoorDash · Seattle"
- **Colophon lede**: states the Meta chapter wrapped in July 2026 and describes the current role at DoorDash — designing merchant experiences that help businesses expand their market
- **Meta chapters (MRB Display, Ray-Ban Meta)**: end date `datetime` refined to `2026-07` (visible text unchanged)
- **SEO/social meta**: page description, Open Graph, and Twitter Card descriptions updated to lead with the current DoorDash role
- **JSON-LD**: `jobTitle` bumped to "Staff Product Designer" (`worksFor` was already DoorDash)
- **CLAUDE.md**: project overview updated to match

Content-only changes — no CSS/JS touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GeJrNM6M3ELRkD2TH66nh

---
_Generated by [Claude Code](https://claude.ai/code/session_019GeJrNM6M3ELRkD2TH66nh)_