### PR TITLE
Fix double-tap on footer links site-wide + sync stale resume/meta content

### DIFF
--- a/404.html
+++ b/404.html
@@ -146,8 +146,14 @@
         color: var(--link);
         text-decoration: none;
         transition: color 120ms ease;
+        /* Same iOS single-tap fixes as the main site (style.css): opt the
+           link out of double-tap-to-zoom arbitration and gate :hover to real
+           pointers so a first tap isn't spent applying the hover state. */
+        touch-action: manipulation;
       }
-      .copy .home:hover { color: var(--link-hover); }
+      @media (hover: hover) {
+        .copy .home:hover { color: var(--link-hover); }
+      }
       .copy .home:focus-visible {
         outline: 2px solid var(--link);
         outline-offset: 4px;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,18 +21,29 @@ Intentionally minimal: hand-written **HTML and CSS**, plus **one small vanilla-J
 ```
 /
 ├── index.html              # The entire site — intro + 4 project chapters + colophon
-├── style.css               # All styles
+├── style.css               # All styles (loaded by index.html only)
 ├── script.js               # Progressive enhancement: media stacks + lightbox
+├── 404.html                # Self-contained animated 404 page (own inline styles/JS)
+├── resume/index.html       # Standalone resume page (own inline styles)
+├── work/                   # Password-gated case-study viewer (own inline styles)
+│   ├── index.html          # Gate + deck shell
+│   ├── rayban-display/     # Exported case-study deck
+│   └── rayban-meta/        # Exported case-study deck
 ├── CNAME                   # GitHub Pages custom domain (www.zacharyhalvorson.com)
+├── vercel.json             # Vercel config (preview deploys)
 ├── favicon.ico             # Favicon
 ├── favicon-152.png         # Apple touch icon (152px)
 ├── apple-touch-icon.png    # Apple touch icon
-├── embed-image.png         # Open Graph / social preview image
-└── images/
-    ├── me/                 # Profile photos (400w, 600w, 1200w, full)
+├── embed-image.jpg         # Open Graph / social preview image
+├── embed-404.png           # Social preview image for the 404 page
+└── media/
+    ├── me/                 # Profile photos (400w, 800w, 1600w; jpg + webp)
     ├── socials/            # Social media icons (GitHub, LinkedIn, etc.)
-    └── work/               # One representative image per project
+    ├── awards/             # Award logos
+    └── work-samples/       # Per-project media for the chapters
 ```
+
+Note: `resume/`, `work/`, and `404.html` do NOT load `style.css` — each carries its own inline `<style>`. Cross-cutting fixes made in `style.css` (e.g. link `touch-action`, `@media (hover: hover)` gates) must be mirrored into those pages' inline styles.
 
 ## Development
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="canonical" href="https://zacharyhalvorson.com/">
 
     <title>Zachary Halvorson — Product Designer</title>
-    <meta name="description" content="Zachary Halvorson is a Staff Product Designer at DoorDash, building merchant experiences that help businesses expand their market. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
+    <meta name="description" content="Zachary Halvorson is a Staff Product Designer at DoorDash, building merchant experiences. Shipped Meta Ray-Ban Display, Ray-Ban Meta, Clio Scheduler, and Dooly.">
     <meta name="author" content="Zachary Halvorson">
 
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
@@ -132,7 +132,7 @@
           <header class="chapter_meta">
             <span class="chapter_index">02 <span aria-hidden="true">/</span> 06</span>
             <p class="chapter_role">Staff Product Designer · Meta Reality Labs</p>
-            <p class="chapter_when"><time datetime="2020">2020</time> to <time datetime="2026-07">2026</time></p>
+            <p class="chapter_when"><time datetime="2020-08">2020</time> to <time datetime="2026-07">2026</time></p>
             <p class="chapter_where">Seattle, WA</p>
           </header>
           <div class="chapter_body">
@@ -172,7 +172,7 @@
           <header class="chapter_meta">
             <span class="chapter_index">03 <span aria-hidden="true">/</span> 06</span>
             <p class="chapter_role">Staff Product Designer · Meta Reality Labs</p>
-            <p class="chapter_when"><time datetime="2020">2020</time> to <time datetime="2026-07">2026</time></p>
+            <p class="chapter_when"><time datetime="2020-08">2020</time> to <time datetime="2026-07">2026</time></p>
             <p class="chapter_where">Seattle, WA</p>
           </header>
           <div class="chapter_body">

--- a/resume/index.html
+++ b/resume/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Zachary Halvorson — Resume</title>
-  <meta name="description" content="Resume of Zachary Halvorson, product designer at Meta Reality Labs.">
+  <meta name="description" content="Resume of Zachary Halvorson, Staff Product Designer at DoorDash.">
   <meta name="author" content="Zachary Halvorson">
   <meta name="robots" content="noindex">
   <link rel="canonical" href="https://www.zacharyhalvorson.com/resume/">
@@ -76,8 +76,16 @@
     a {
       color: var(--link);
       text-decoration: none;
+      /* Same iOS single-tap fixes as the main site (style.css): opt links
+         (and their wrapped children) out of double-tap-to-zoom arbitration,
+         and gate :hover to real pointers so a first tap isn't spent applying
+         the hover state. */
+      touch-action: manipulation;
     }
-    a:hover { color: var(--link-hover); text-decoration: underline; }
+    a * { touch-action: manipulation; }
+    @media (hover: hover) {
+      a:hover { color: var(--link-hover); text-decoration: underline; }
+    }
     a:focus-visible {
       outline: 2px solid var(--link);
       outline-offset: 2px;
@@ -242,17 +250,29 @@
 
     <section class="job">
       <h3 class="job_title">
-        Product Designer,
+        Staff Product Designer,
+        <a href="https://www.doordash.com/" target="_blank" rel="noopener noreferrer">DoorDash</a>
+      </h3>
+      <p class="job_meta">Seattle, WA &ndash; <time datetime="2026-07">July 2026</time>-Present</p>
+      <p>
+        I design merchant experiences at DoorDash, helping businesses expand
+        their market.
+      </p>
+    </section>
+
+    <section class="job">
+      <h3 class="job_title">
+        Staff Product Designer,
         <a href="https://about.meta.com/realitylabs/" target="_blank" rel="noopener noreferrer">Meta Reality Labs</a>
       </h3>
-      <p class="job_meta">Seattle, WA &ndash; <time datetime="2020-08">August 2020</time>-<time datetime="2026-05">May 2026</time></p>
+      <p class="job_meta">Seattle, WA &ndash; <time datetime="2020-08">August 2020</time>-<time datetime="2026-07">July 2026</time></p>
       <p>
         I focussed on AI experiences on Wearables within Meta&rsquo;s Reality
         Labs. In my time at Meta I have worked on AI Smart Glasses in a holistic
         way. Championing multiple devices and individual features from concept
         phase to launching into the market.
       </p>
-      <p>As a Product Designer on wearables, my work has included:</p>
+      <p>As a product designer on wearables, my work has included:</p>
       <ul>
         <li>AI-native feature ideation, design, and execution.</li>
         <li>Leveraging a deep understanding of networked devices in managing the connectivity of the wearables.</li>

--- a/style.css
+++ b/style.css
@@ -99,6 +99,17 @@ a {
      (pan + pinch stay available) so a single tap always clicks. */
   touch-action: manipulation;
 }
+/* touch-action is NOT inherited — iOS Safari evaluates it on the element the
+   finger actually lands on (the same finding stamped onto `.media.is-stack *`
+   and `.lightbox *`). Inline text links hit-test to the <a> itself, so the
+   rule above covers them; the socials pills do not — their whole surface is
+   wrapped children (<img class="socials_icon">, <span>GitHub</span>), so every
+   tap targets a descendant still at `touch-action: auto` and goes back through
+   the double-tap-to-zoom arbitration the <a> opted out of. Stamp the opt-out
+   onto link descendants too. (Class-level touch-action rules — `.lightbox *`:
+   none, `.media.is-stack *`: pan-y — outrank this element selector, so gesture
+   locking inside those components is unaffected.) */
+a * { touch-action: manipulation; }
 /* Hover affordances are gated to real pointers. On iOS Safari (`hover: none`)
    a link with a :hover style applies that hover state on the first tap and
    only navigates on a second tap — the "tap once, nothing happens, tap again"

--- a/style.css
+++ b/style.css
@@ -91,25 +91,17 @@ a {
   text-decoration-thickness: 1px;
   text-underline-offset: 0.18em;
   transition: color 120ms var(--ease);
-  /* The page stays pinch-zoomable (no maximum-scale — accessibility), which
-     leaves iOS Safari's double-tap-to-zoom heuristic arbitrating every tap on
-     zoomable text. A tap on a small inline link inside a paragraph can be
-     held back as a potential first half of a text zoom instead of dispatched
-     as a click. `manipulation` opts the link itself out of that arbitration
-     (pan + pinch stay available) so a single tap always clicks. */
-  touch-action: manipulation;
 }
-/* touch-action is NOT inherited — iOS Safari evaluates it on the element the
-   finger actually lands on (the same finding stamped onto `.media.is-stack *`
-   and `.lightbox *`). Inline text links hit-test to the <a> itself, so the
-   rule above covers them; the socials pills do not — their whole surface is
-   wrapped children (<img class="socials_icon">, <span>GitHub</span>), so every
-   tap targets a descendant still at `touch-action: auto` and goes back through
-   the double-tap-to-zoom arbitration the <a> opted out of. Stamp the opt-out
-   onto link descendants too. (Class-level touch-action rules — `.lightbox *`:
-   none, `.media.is-stack *`: pan-y — outrank this element selector, so gesture
-   locking inside those components is unaffected.) */
-a * { touch-action: manipulation; }
+/* The page stays pinch-zoomable (no maximum-scale — accessibility), which
+   leaves iOS Safari's double-tap-to-zoom heuristic arbitrating every tap on
+   zoomable text; a tap on a small link can be held back as a potential first
+   half of a text zoom instead of dispatched as a click. `manipulation` opts
+   links out (pan + pinch stay available) so a single tap always clicks.
+   Stamped onto descendants too because some links' whole surface is wrapped
+   children — the socials pills' <img>/<span> — and iOS evaluates touch-action
+   on the element the finger lands on (see `.media.is-stack *`, `.lightbox *`,
+   whose class selectors still outrank this). */
+a, a * { touch-action: manipulation; }
 /* Hover affordances are gated to real pointers. On iOS Safari (`hover: none`)
    a link with a :hover style applies that hover state on the first tap and
    only navigates on a second tap — the "tap once, nothing happens, tap again"

--- a/work/index.html
+++ b/work/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Selected Work — Zachary Halvorson</title>
-  <meta name="description" content="Password-protected case studies by Zachary Halvorson, product designer at Meta Reality Labs.">
+  <meta name="description" content="Password-protected case studies by Zachary Halvorson, Staff Product Designer at DoorDash.">
   <meta name="author" content="Zachary Halvorson">
   <meta name="robots" content="noindex, nofollow">
   <link rel="canonical" href="https://www.zacharyhalvorson.com/work/">
@@ -108,8 +108,16 @@
     a {
       color: var(--link);
       text-decoration: none;
+      /* Same iOS single-tap fixes as the main site (style.css): opt links
+         (and their wrapped children — .back's whole surface is an <svg>) out
+         of double-tap-to-zoom arbitration, and gate :hover to real pointers
+         so a first tap isn't spent applying the hover state. */
+      touch-action: manipulation;
     }
-    a:hover { color: var(--link-hover); text-decoration: underline; }
+    a * { touch-action: manipulation; }
+    @media (hover: hover) {
+      a:hover { color: var(--link-hover); text-decoration: underline; }
+    }
 
     :focus-visible {
       outline: 2px solid var(--link);
@@ -171,7 +179,11 @@
       border: none;
       border-radius: 999px;
       cursor: pointer;
+      touch-action: manipulation;
     }
+    /* touch-action is not inherited on iOS: cover the buttons' <svg> icons
+       too (the .back anchor's svg is already covered by `a *` above). */
+    .rail-toggle *, .fullscreen-toggle * { touch-action: manipulation; }
     .back { left: 0.6rem; }
     .rail-toggle { right: 0.6rem; }
     .fullscreen-toggle { right: 3rem; }
@@ -180,10 +192,12 @@
        without this the button would still render where the JS leaves it
        hidden (no Fullscreen API). Same guard .app[hidden] / #gate[hidden] use. */
     .fullscreen-toggle[hidden] { display: none; }
-    .back:hover, .rail-toggle:hover, .fullscreen-toggle:hover {
-      color: var(--text-default);
-      background: var(--press);
-      text-decoration: none;
+    @media (hover: hover) {
+      .back:hover, .rail-toggle:hover, .fullscreen-toggle:hover {
+        color: var(--text-default);
+        background: var(--press);
+        text-decoration: none;
+      }
     }
     /* All three chrome icons share one resting tint and only darken on hover,
        so they read as one set. (The navigator toggle used to stay darkened


### PR DESCRIPTION
## Problem

After #71, the footer's GitHub/LinkedIn/Email pill buttons still needed two taps on iOS. A full code review of the fix then surfaced that the tap fixes never reached the standalone pages at all, plus content drift left behind by the recent DoorDash update.

## Tap fixes

- **Root cause on the pills**: their entire visible surface is wrapped children (`<img class="socials_icon">`, `<span>GitHub</span>`). iOS Safari evaluates `touch-action` on the element the finger lands on — the same non-inheritance finding this codebase already documents for `.media.is-stack *` and `.lightbox *` — so taps on a pill targeted descendants still at `touch-action: auto`. The opt-out is now one merged rule: `a, a * { touch-action: manipulation; }`.
- **Coverage gap**: `style.css` is only loaded by `index.html`. `resume/`, `work/`, and `404.html` carry their own inline styles with the already-diagnosed first-tap eaters intact (ungated `a:hover`, no `touch-action`, and the work shell's `.back` anchor whose whole surface is an `<svg>`). Both halves of the fix (link `touch-action` + `@media (hover: hover)` gating) are now ported into all three pages, including the deck toolbar buttons.
- The class-level gesture locks (`.lightbox *`: `none`, `.media.is-stack *`: `pan-y`) outrank the new rule, so lightbox/stack handling is unchanged.

## Content consistency (secondary pages vs. homepage)

- `resume/index.html`: adds the DoorDash entry (Staff Product Designer, July 2026–Present), retitles the Meta role to match the homepage's "Staff Product Designer", corrects its end date May → July 2026, and updates the stale "product designer at Meta Reality Labs" meta description.
- `work/index.html`: same stale meta description updated.
- `index.html`: Meta start dates upgraded from `datetime="2020"` to the site's YYYY-MM convention; meta description trimmed under the ~160-char SERP render limit (matching og:description) so the shipped-products clause survives truncation.
- `CLAUDE.md`: repository tree corrected (`images/` → `media/`, `embed-image.jpg`, adds `resume/`, `work/`, `404.html`, `vercel.json`) with a note that the standalone pages don't load `style.css`.

**Intentionally not changed:** the "Product Designer" phrasing in `<title>`/og:title (explicit decision in #69), the case-study deck's "Design Lead" byline (historical project credit), and the colophon lede's wording.

## Verification

Chromium touch emulation across all four pages: links and their wrapped children compute `touch-action: manipulation`; lightbox (`none`) and media-stack (`pan-y`) locks unaffected; hover rules media-gated; a settled single tap on a socials pill dispatches exactly one click; resume renders DoorDash → Meta with consistent titles/dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMZJL7B38ycr7ba1sA825f